### PR TITLE
[TIL-36] 회원가입, 닉네임 중복 확인 기능 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ out/
 
 ## docker
 db/
+!til-*/**/db/
 
 ## Mac
 .DS_Store

--- a/til-api/src/main/java/com/til/common/response/ApiResponse.java
+++ b/til-api/src/main/java/com/til/common/response/ApiResponse.java
@@ -24,6 +24,10 @@ public class ApiResponse<T> {
 		return new ApiResponse<>(BaseSuccessCode.OK, null);
 	}
 
+	public static <T> ApiResponse<T> ok(SuccessCode status) {
+		return new ApiResponse<>(status, null);
+	}
+
 	public static <T> ApiResponse<T> ok(T data) {
 		return new ApiResponse<>(BaseSuccessCode.OK, data);
 	}

--- a/til-api/src/main/java/com/til/common/response/ApiStatus.java
+++ b/til-api/src/main/java/com/til/common/response/ApiStatus.java
@@ -22,4 +22,8 @@ public class ApiStatus {
 	public static ApiStatus of(ErrorCode status) {
 		return new ApiStatus(status.name(), status.getMessage());
 	}
+
+	public static ApiStatus of(String code, String message) {
+		return new ApiStatus(code, message);
+	}
 }

--- a/til-api/src/main/java/com/til/config/errorhandling/ErrorResponse.java
+++ b/til-api/src/main/java/com/til/config/errorhandling/ErrorResponse.java
@@ -13,7 +13,15 @@ public class ErrorResponse {
 		this.status = ApiStatus.of(status);
 	}
 
+	private ErrorResponse(String code, String message) {
+		this.status = ApiStatus.of(code, message);
+	}
+
 	public static ErrorResponse of(ErrorCode status) {
 		return new ErrorResponse(status);
+	}
+
+	public static ErrorResponse of(String code, String message) {
+		return new ErrorResponse(code, message);
 	}
 }

--- a/til-api/src/main/java/com/til/config/errorhandling/GlobalExceptionHandler.java
+++ b/til-api/src/main/java/com/til/config/errorhandling/GlobalExceptionHandler.java
@@ -17,6 +17,7 @@ import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExcep
 
 import com.til.domain.common.enums.BaseErrorCode;
 import com.til.domain.common.exception.BaseException;
+import com.til.domain.common.exception.InvalidDtoException;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -30,6 +31,16 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 
 		return ResponseEntity
 			.status(ex.getErrorCode().getStatus().value())
+			.body(response);
+	}
+
+	@ExceptionHandler(InvalidDtoException.class)
+	protected ResponseEntity<ErrorResponse> handleInvalidDtoException(final InvalidDtoException ex) {
+		log.error("InvalidDtoException: {}", ex.getMessage());
+		ErrorResponse response = ErrorResponse.of("INVALID_DTO", ex.getMessage());
+
+		return ResponseEntity
+			.status(HttpStatus.BAD_REQUEST)
 			.body(response);
 	}
 

--- a/til-api/src/main/java/com/til/config/errorhandling/GlobalExceptionHandler.java
+++ b/til-api/src/main/java/com/til/config/errorhandling/GlobalExceptionHandler.java
@@ -21,8 +21,8 @@ import com.til.domain.common.exception.InvalidDtoException;
 
 import lombok.extern.slf4j.Slf4j;
 
-@Slf4j
 @RestControllerAdvice
+@Slf4j
 public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 	@ExceptionHandler(BaseException.class)
 	protected ResponseEntity<ErrorResponse> handleCustomException(final BaseException ex) {

--- a/til-api/src/main/java/com/til/controller/user/UserController.java
+++ b/til-api/src/main/java/com/til/controller/user/UserController.java
@@ -1,5 +1,7 @@
 package com.til.controller.user;
 
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -23,5 +25,11 @@ public class UserController {
 	public ApiResponse join(@RequestBody @Valid UserJoinRequest request) {
 		userService.join(request.toServiceDto());
 		return ApiResponse.ok(UserSuccessCode.SUCCESS_JOIN);
+	}
+
+	@GetMapping("/nickname/{nickname}")
+	public ApiResponse checkNickname(@PathVariable String nickname) {
+		userService.checkNickname(nickname);
+		return ApiResponse.ok(UserSuccessCode.POSSIBLE_NICKNAME);
 	}
 }

--- a/til-api/src/main/java/com/til/controller/user/UserController.java
+++ b/til-api/src/main/java/com/til/controller/user/UserController.java
@@ -1,4 +1,27 @@
 package com.til.controller.user;
 
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.til.application.user.UserService;
+import com.til.common.response.ApiResponse;
+import com.til.controller.user.request.UserJoinRequest;
+import com.til.domain.user.enums.UserSuccessCode;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/user")
 public class UserController {
+	private final UserService userService;
+
+	@PostMapping("/join")
+	public ApiResponse join(@RequestBody @Valid UserJoinRequest request) {
+		userService.join(request.toServiceDto());
+		return ApiResponse.ok(UserSuccessCode.SUCCESS_JOIN);
+	}
 }

--- a/til-api/src/main/java/com/til/controller/user/request/UserJoinRequest.java
+++ b/til-api/src/main/java/com/til/controller/user/request/UserJoinRequest.java
@@ -1,0 +1,20 @@
+package com.til.controller.user.request;
+
+import com.til.domain.user.dto.UserJoinDto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+public record UserJoinRequest(
+	@NotBlank(message = "이메일은 필수 항목입니다.") @Email String email,
+	@NotBlank(message = "비밀번호는 필수 항목입니다.") String password,
+	@NotBlank(message = "닉네임은 필수 항목입니다.") String nickname
+) {
+	public UserJoinDto toServiceDto() {
+		return UserJoinDto.builder()
+			.email(email)
+			.password(password)
+			.nickname(nickname)
+			.build();
+	}
+}

--- a/til-domain/src/main/java/com/til/application/user/UserService.java
+++ b/til-domain/src/main/java/com/til/application/user/UserService.java
@@ -14,8 +14,8 @@ import com.til.domain.user.validator.UserInfoValidator;
 import lombok.RequiredArgsConstructor;
 
 @Service
-@Transactional(readOnly = true)
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class UserService {
 	private final UserRepository userRepository;
 	private final PasswordEncoder passwordEncoder;

--- a/til-domain/src/main/java/com/til/application/user/UserService.java
+++ b/til-domain/src/main/java/com/til/application/user/UserService.java
@@ -29,14 +29,18 @@ public class UserService {
 		if (userRepository.existsByEmail(userJoinDto.email())) {
 			throw new BaseException(UserErrorCode.ALREADY_EXISTS_EMAIL);
 		}
-		if (userRepository.existsByNickname(userJoinDto.nickname())) {
-			throw new BaseException(UserErrorCode.ALREADY_EXISTS_NICKNAME);
-		}
+		checkNickname(userJoinDto.nickname());
 
 		String encodePassword = passwordEncoder.encode(userJoinDto.password());
 		User user = userJoinDto.toEntity();
 		user.setPassword(encodePassword);
 
 		userRepository.save(user);
+	}
+
+	public void checkNickname(String nickname) {
+		if (userRepository.existsByNickname(nickname)) {
+			throw new BaseException(UserErrorCode.ALREADY_EXISTS_NICKNAME);
+		}
 	}
 }

--- a/til-domain/src/main/java/com/til/application/user/UserService.java
+++ b/til-domain/src/main/java/com/til/application/user/UserService.java
@@ -1,4 +1,42 @@
 package com.til.application.user;
 
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.til.domain.common.exception.BaseException;
+import com.til.domain.user.dto.UserJoinDto;
+import com.til.domain.user.enums.UserErrorCode;
+import com.til.domain.user.model.User;
+import com.til.domain.user.repository.UserRepository;
+import com.til.domain.user.validator.UserInfoValidator;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
 public class UserService {
+	private final UserRepository userRepository;
+	private final PasswordEncoder passwordEncoder;
+
+	private final UserInfoValidator userInfoValidator;
+
+	@Transactional
+	public void join(UserJoinDto userJoinDto) {
+		userInfoValidator.validateJoinInfo(userJoinDto.nickname(), userJoinDto.password());
+
+		if (userRepository.existsByEmail(userJoinDto.email())) {
+			throw new BaseException(UserErrorCode.ALREADY_EXISTS_EMAIL);
+		}
+		if (userRepository.existsByNickname(userJoinDto.nickname())) {
+			throw new BaseException(UserErrorCode.ALREADY_EXISTS_NICKNAME);
+		}
+
+		String encodePassword = passwordEncoder.encode(userJoinDto.password());
+		User user = userJoinDto.toEntity();
+		user.setPassword(encodePassword);
+
+		userRepository.save(user);
+	}
 }

--- a/til-domain/src/main/java/com/til/config/db/JpaConfig.java
+++ b/til-domain/src/main/java/com/til/config/db/JpaConfig.java
@@ -1,0 +1,10 @@
+package com.til.config.db;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaConfig {
+	// JPA 설정을 위한 클래스
+}

--- a/til-domain/src/main/java/com/til/config/security/PasswordConfig.java
+++ b/til-domain/src/main/java/com/til/config/security/PasswordConfig.java
@@ -1,0 +1,14 @@
+package com.til.config.security;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Configuration
+public class PasswordConfig {
+	@Bean
+	public PasswordEncoder passwordEncoder() {
+		return new BCryptPasswordEncoder();
+	}
+}

--- a/til-domain/src/main/java/com/til/domain/common/exception/InvalidDtoException.java
+++ b/til-domain/src/main/java/com/til/domain/common/exception/InvalidDtoException.java
@@ -1,0 +1,7 @@
+package com.til.domain.common.exception;
+
+public class InvalidDtoException extends RuntimeException {
+	public InvalidDtoException(String message) {
+		super(message);
+	}
+}

--- a/til-domain/src/main/java/com/til/domain/common/model/BaseTimeEntity.java
+++ b/til-domain/src/main/java/com/til/domain/common/model/BaseTimeEntity.java
@@ -14,11 +14,11 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 
+@MappedSuperclass
 @Getter
 @SuperBuilder
-@MappedSuperclass
-@EntityListeners(AuditingEntityListener.class)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
 public abstract class BaseTimeEntity {
 	@CreatedDate
 	@Column(name = "created_date", nullable = false, updatable = false)

--- a/til-domain/src/main/java/com/til/domain/common/model/BaseTimeEntity.java
+++ b/til-domain/src/main/java/com/til/domain/common/model/BaseTimeEntity.java
@@ -1,0 +1,30 @@
+package com.til.domain.common.model;
+
+import java.time.LocalDateTime;
+
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+@Getter
+@SuperBuilder
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public abstract class BaseTimeEntity {
+	@CreatedDate
+	@Column(name = "created_date", nullable = false, updatable = false)
+	private LocalDateTime createdDate;
+
+	@LastModifiedDate
+	@Column(name = "modified_date", nullable = false)
+	private LocalDateTime modifiedDate;
+}

--- a/til-domain/src/main/java/com/til/domain/user/dto/UserJoinDto.java
+++ b/til-domain/src/main/java/com/til/domain/user/dto/UserJoinDto.java
@@ -1,0 +1,26 @@
+package com.til.domain.user.dto;
+
+import com.til.domain.user.model.Platform;
+import com.til.domain.user.model.Role;
+import com.til.domain.user.model.Status;
+import com.til.domain.user.model.User;
+
+import lombok.Builder;
+
+@Builder
+public record UserJoinDto(
+	String email,
+	String password,
+	String nickname
+) {
+	public User toEntity() {
+		return User.builder()
+			.email(email)
+			.password(password)
+			.nickname(nickname)
+			.platform(Platform.TIL)
+			.role(Role.USER)
+			.status(Status.ACTIVE)
+			.build();
+	}
+}

--- a/til-domain/src/main/java/com/til/domain/user/enums/UserErrorCode.java
+++ b/til-domain/src/main/java/com/til/domain/user/enums/UserErrorCode.java
@@ -1,0 +1,22 @@
+package com.til.domain.user.enums;
+
+import org.springframework.http.HttpStatus;
+
+import com.til.domain.common.enums.ErrorCode;
+
+import lombok.Getter;
+
+@Getter
+public enum UserErrorCode implements ErrorCode {
+	ALREADY_EXISTS_NICKNAME(HttpStatus.BAD_REQUEST, "이미 존재하는 닉네임입니다."),
+	ALREADY_EXISTS_EMAIL(HttpStatus.BAD_REQUEST, "이미 존재하는 이메일입니다."),
+	NOT_FOUND_USER(HttpStatus.NOT_FOUND, "해당 사용자를 찾을 수 없습니다.");
+
+	private final HttpStatus status;
+	private final String message;
+
+	UserErrorCode(HttpStatus status, String message) {
+		this.status = status;
+		this.message = message;
+	}
+}

--- a/til-domain/src/main/java/com/til/domain/user/enums/UserSuccessCode.java
+++ b/til-domain/src/main/java/com/til/domain/user/enums/UserSuccessCode.java
@@ -1,0 +1,16 @@
+package com.til.domain.user.enums;
+
+import com.til.domain.common.enums.SuccessCode;
+
+import lombok.Getter;
+
+@Getter
+public enum UserSuccessCode implements SuccessCode {
+	SUCCESS_JOIN("회원가입에 성공하였습니다.");
+
+	private final String message;
+
+	UserSuccessCode(String message) {
+		this.message = message;
+	}
+}

--- a/til-domain/src/main/java/com/til/domain/user/enums/UserSuccessCode.java
+++ b/til-domain/src/main/java/com/til/domain/user/enums/UserSuccessCode.java
@@ -6,7 +6,8 @@ import lombok.Getter;
 
 @Getter
 public enum UserSuccessCode implements SuccessCode {
-	SUCCESS_JOIN("회원가입에 성공하였습니다.");
+	SUCCESS_JOIN("회원가입에 성공하였습니다."),
+	POSSIBLE_NICKNAME("사용 가능한 닉네임입니다.");
 
 	private final String message;
 

--- a/til-domain/src/main/java/com/til/domain/user/model/Platform.java
+++ b/til-domain/src/main/java/com/til/domain/user/model/Platform.java
@@ -1,0 +1,8 @@
+package com.til.domain.user.model;
+
+public enum Platform {
+	TIL,
+	NAVER,
+	KAKAO,
+	GOOGLE
+}

--- a/til-domain/src/main/java/com/til/domain/user/model/Role.java
+++ b/til-domain/src/main/java/com/til/domain/user/model/Role.java
@@ -1,0 +1,6 @@
+package com.til.domain.user.model;
+
+public enum Role {
+	USER,
+	ADMIN
+}

--- a/til-domain/src/main/java/com/til/domain/user/model/Status.java
+++ b/til-domain/src/main/java/com/til/domain/user/model/Status.java
@@ -1,0 +1,8 @@
+package com.til.domain.user.model;
+
+public enum Status {
+	ACTIVE,
+	INACTIVE,
+	STOP,
+	DELETED
+}

--- a/til-domain/src/main/java/com/til/domain/user/model/User.java
+++ b/til-domain/src/main/java/com/til/domain/user/model/User.java
@@ -9,6 +9,7 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -18,6 +19,7 @@ import lombok.experimental.SuperBuilder;
 @Getter
 @SuperBuilder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "user")
 public class User extends BaseTimeEntity {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/til-domain/src/main/java/com/til/domain/user/model/User.java
+++ b/til-domain/src/main/java/com/til/domain/user/model/User.java
@@ -1,0 +1,50 @@
+package com.til.domain.user.model;
+
+import com.til.domain.common.model.BaseTimeEntity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+@Entity
+@Getter
+@SuperBuilder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class User extends BaseTimeEntity {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@Column(nullable = false)
+	private String email;
+
+	@Column(nullable = false)
+	private String password;
+
+	@Column(nullable = false)
+	private String nickname;
+
+	@Enumerated(EnumType.STRING)
+	@Column(nullable = false)
+	private Platform platform;
+
+	@Enumerated(EnumType.STRING)
+	@Column(nullable = false)
+	private Role role;
+
+	@Enumerated(EnumType.STRING)
+	@Column(nullable = false)
+	private Status status;
+
+	public void setPassword(String password) {
+		this.password = password;
+	}
+}

--- a/til-domain/src/main/java/com/til/domain/user/repository/UserRepository.java
+++ b/til-domain/src/main/java/com/til/domain/user/repository/UserRepository.java
@@ -1,0 +1,11 @@
+package com.til.domain.user.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.til.domain.user.model.User;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+	boolean existsByEmail(String email);
+
+	boolean existsByNickname(String nickname);
+}

--- a/til-domain/src/main/java/com/til/domain/user/validator/UserInfoValidator.java
+++ b/til-domain/src/main/java/com/til/domain/user/validator/UserInfoValidator.java
@@ -1,0 +1,28 @@
+package com.til.domain.user.validator;
+
+import org.springframework.stereotype.Component;
+
+import com.til.domain.common.exception.InvalidDtoException;
+
+@Component
+public class UserInfoValidator {
+	private static final String NICKNAME_REGEX = "^[가-힣A-Za-z0-9]{2,12}$";
+	private static final String PASSWORD_REGEX = "^(?=.*[A-Za-z])(?=.*\\d)[A-Za-z\\d]{8,20}$";
+
+	public void validateJoinInfo(String nickname, String password) {
+		validateNickname(nickname);
+		validatePassword(password);
+	}
+
+	private void validateNickname(String nickname) {
+		if (!nickname.matches(NICKNAME_REGEX)) {
+			throw new InvalidDtoException("닉네임은 한글, 영문, 숫자로 2자 이상 12자 이하로 입력해주세요.");
+		}
+	}
+
+	private void validatePassword(String password) {
+		if (!password.matches(PASSWORD_REGEX)) {
+			throw new InvalidDtoException("비밀번호는 영문, 숫자 조합으로 8자 이상 20자 이하로 입력해주세요.");
+		}
+	}
+}

--- a/til-domain/src/test/java/com/til/application/user/UserServiceTest.java
+++ b/til-domain/src/test/java/com/til/application/user/UserServiceTest.java
@@ -3,7 +3,6 @@ package com.til.application.user;
 import static org.assertj.core.api.AssertionsForClassTypes.*;
 import static org.mockito.BDDMockito.*;
 
-import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -27,8 +26,7 @@ class UserServiceTest {
 	private UserRepository userRepository;
 
 	@Test
-	@DisplayName("중복되는 이메일은 회원가입할 수 없다.")
-	void joinFailWhenEmailDuplicated() {
+	void 회원가입시_이메일이_중복되면_예외를_던진다() {
 		// given
 		given(userRepository.existsByEmail(anyString())).willReturn(true);
 
@@ -42,8 +40,7 @@ class UserServiceTest {
 	}
 
 	@Test
-	@DisplayName("중복되는 닉네임은 회원가입할 수 없다.")
-	void joinFailWhenNicknameDuplicated() {
+	void 회원가입시_닉네임이_중복되면_예외를_던진다() {
 		// given
 		given(userRepository.existsByEmail(anyString())).willReturn(false);
 		given(userRepository.existsByNickname(anyString())).willReturn(true);

--- a/til-domain/src/test/java/com/til/application/user/UserServiceTest.java
+++ b/til-domain/src/test/java/com/til/application/user/UserServiceTest.java
@@ -56,8 +56,8 @@ class UserServiceTest {
 
 	private UserJoinDto createUserJoinDto() {
 		return UserJoinDto.builder()
-			.email("sun@til.com")
-			.password("pw@2024!")
+			.email("test@til.com")
+			.password("soma2024")
 			.nickname("선인장24")
 			.build();
 	}

--- a/til-domain/src/test/java/com/til/application/user/UserServiceTest.java
+++ b/til-domain/src/test/java/com/til/application/user/UserServiceTest.java
@@ -1,0 +1,67 @@
+package com.til.application.user;
+
+import static org.assertj.core.api.AssertionsForClassTypes.*;
+import static org.mockito.BDDMockito.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.til.domain.common.exception.BaseException;
+import com.til.domain.user.dto.UserJoinDto;
+import com.til.domain.user.repository.UserRepository;
+import com.til.domain.user.validator.UserInfoValidator;
+
+@ExtendWith(MockitoExtension.class)
+class UserServiceTest {
+	@InjectMocks
+	private UserService userService;
+
+	@Mock
+	private UserInfoValidator userInfoValidator;
+
+	@Mock
+	private UserRepository userRepository;
+
+	@Test
+	@DisplayName("중복되는 이메일은 회원가입할 수 없다.")
+	void joinFailWhenEmailDuplicated() {
+		// given
+		given(userRepository.existsByEmail(anyString())).willReturn(true);
+
+		UserJoinDto userJoinDto = createUserJoinDto();
+
+		// when
+		Throwable throwable = catchThrowable(() -> userService.join(userJoinDto));
+
+		// then
+		assertThat(throwable).isInstanceOf(BaseException.class);
+	}
+
+	@Test
+	@DisplayName("중복되는 닉네임은 회원가입할 수 없다.")
+	void joinFailWhenNicknameDuplicated() {
+		// given
+		given(userRepository.existsByEmail(anyString())).willReturn(false);
+		given(userRepository.existsByNickname(anyString())).willReturn(true);
+
+		UserJoinDto userJoinDto = createUserJoinDto();
+
+		// when
+		Throwable throwable = catchThrowable(() -> userService.join(userJoinDto));
+
+		// then
+		assertThat(throwable).isInstanceOf(BaseException.class);
+	}
+
+	private UserJoinDto createUserJoinDto() {
+		return UserJoinDto.builder()
+			.email("sun@til.com")
+			.password("pw@2024!")
+			.nickname("선인장24")
+			.build();
+	}
+}


### PR DESCRIPTION
## 이슈 번호(링크)

[TIL-36](https://soma-til.atlassian.net/browse/TIL-36)

<br>

## 개요
- 회원가입 기능 API
- 닉네임 중복 확인 API

<br>

## 내용
- User table 구조
  ![image](https://github.com/SOMA-TIL/TIL-Backend/assets/74449232/1fc77c2a-ae85-4980-957f-56b410d571b6)

- 회원가입 기능 API : [API 문서](https://soma-til.notion.site/440844f1a02d4511b1341184965aebb3)
  - 이메일, 패스워드, 닉네임 정보를 받아 데이터가 유효한지 검증
  - 유효하다면 회원가입 진행
- 닉네임 중복 확인 API : [API 문서](https://soma-til.notion.site/8211e20e2a064605b3c2a89c612ee237)
  - 당장 필요없는 기능이긴 하지만 회원가입 기능 구현하며 닉네임 중복 확인 로직이 있어 포함시켜 작업 진행

<br>

## 리뷰어한테 할 말
- 계층별 dto 검증 범위에 대해서는 아래와 같은 기준으로 우선 적용하였습니다.
  - api 모듈 dto 검증 : 데이터가 필수로 입력되어야 하는지 같은 기본적인 검증
  - domain 모듈 dto 검증 : 비즈니스적인 측면(TIL 정책)에 대한 검증
    ex) com.til.domain.user.validator.`UserInfoValidator`는 사용자 정보에 대한 검증을 모아둠


[TIL-36]: https://soma-til.atlassian.net/browse/TIL-36?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ