### PR TITLE
[TIL-26] Redis 연동 및 로그인 기능 구현

### DIFF
--- a/docker-compose-local.yml
+++ b/docker-compose-local.yml
@@ -13,3 +13,28 @@ services:
       MYSQL_DATABASE: til
       MYSQL_ROOT_HOST: '%'
       MYSQL_ROOT_PASSWORD: pw@1234
+
+  redis:
+    image: redis:latest
+    container_name: redis_server
+    volumes:
+      - ./db/redis/data:/data
+    ports:
+      - "6379:6379"
+    networks:
+      - redis_network
+    command: [ "sh", "-c", "redis-server --requirepass pw@1234 --bind 0.0.0.0" ]
+
+  redis_client:
+    image: redis:latest
+    container_name: redis_client
+    entrypoint: [ "/bin/bash", "-c", "echo 'alias redis-cli-connect=\"redis-cli -h redis_server -a pw@1234\"' >> ~/.bashrc && /bin/bash" ]
+    depends_on:
+      - redis
+    networks:
+      - redis_network
+    stdin_open: true
+    tty: true
+
+networks:
+  redis_network:

--- a/til-api/src/main/java/com/til/controller/user/UserController.java
+++ b/til-api/src/main/java/com/til/controller/user/UserController.java
@@ -7,9 +7,14 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.til.application.auth.AuthService;
 import com.til.application.user.UserService;
 import com.til.common.response.ApiResponse;
 import com.til.controller.user.request.UserJoinRequest;
+import com.til.controller.user.request.UserLoginRequest;
+import com.til.controller.user.response.UserTokenResponse;
+import com.til.domain.auth.dto.AuthTokenDto;
+import com.til.domain.auth.dto.AuthUserInfoDto;
 import com.til.domain.user.enums.UserSuccessCode;
 
 import jakarta.validation.Valid;
@@ -20,11 +25,20 @@ import lombok.RequiredArgsConstructor;
 @RequestMapping("/user")
 public class UserController {
 	private final UserService userService;
+	private final AuthService authService;
 
 	@PostMapping("/join")
 	public ApiResponse join(@RequestBody @Valid UserJoinRequest request) {
 		userService.join(request.toServiceDto());
 		return ApiResponse.ok(UserSuccessCode.SUCCESS_JOIN);
+	}
+
+	@PostMapping("/login")
+	public ApiResponse login(@RequestBody @Valid UserLoginRequest request) {
+		AuthUserInfoDto userInfoDto = userService.login(request.toServiceDto());
+		AuthTokenDto token = authService.createToken(userInfoDto);
+
+		return ApiResponse.ok(UserSuccessCode.SUCCESS_LOGIN, UserTokenResponse.of(token));
 	}
 
 	@GetMapping("/nickname/{nickname}")

--- a/til-api/src/main/java/com/til/controller/user/request/UserLoginRequest.java
+++ b/til-api/src/main/java/com/til/controller/user/request/UserLoginRequest.java
@@ -1,0 +1,18 @@
+package com.til.controller.user.request;
+
+import com.til.domain.user.dto.UserLoginDto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+public record UserLoginRequest(
+	@NotBlank(message = "이메일은 필수 항목입니다.") @Email String email,
+	@NotBlank(message = "비밀번호는 필수 항목입니다.") String password
+) {
+	public UserLoginDto toServiceDto() {
+		return UserLoginDto.builder()
+			.email(email)
+			.password(password)
+			.build();
+	}
+}

--- a/til-api/src/main/java/com/til/controller/user/response/UserTokenResponse.java
+++ b/til-api/src/main/java/com/til/controller/user/response/UserTokenResponse.java
@@ -1,0 +1,12 @@
+package com.til.controller.user.response;
+
+import com.til.domain.auth.dto.AuthTokenDto;
+
+public record UserTokenResponse(
+	String accessToken,
+	String refreshToken
+) {
+	public static UserTokenResponse of(AuthTokenDto authTokenDto) {
+		return new UserTokenResponse(authTokenDto.accessToken(), authTokenDto.refreshToken());
+	}
+}

--- a/til-api/src/main/resources/application.yml
+++ b/til-api/src/main/resources/application.yml
@@ -13,3 +13,10 @@ spring:
     properties:
       hibernate:
         format_sql: true
+
+jwt:
+  secret: secretKey1secretKey2secretKey3secretKey4secretKey5secretKey6secretKey7secretKey8
+  access:
+    expiration: 1800000 # 30 minutes(1000 * 60 * 30)
+  refresh:
+    expiration: 1209600000 # 14 days(1000 * 60 * 60 * 24 * 14)

--- a/til-api/src/main/resources/application.yml
+++ b/til-api/src/main/resources/application.yml
@@ -13,10 +13,15 @@ spring:
     properties:
       hibernate:
         format_sql: true
-
+  data:
+    redis:
+      host: 127.0.0.1
+      port: 6379
+      password: pw@1234
 jwt:
   secret: secretKey1secretKey2secretKey3secretKey4secretKey5secretKey6secretKey7secretKey8
   access:
     expiration: 1800000 # 30 minutes(1000 * 60 * 30)
   refresh:
     expiration: 1209600000 # 14 days(1000 * 60 * 60 * 24 * 14)
+

--- a/til-domain/build.gradle
+++ b/til-domain/build.gradle
@@ -4,4 +4,8 @@ jar.enabled = true
 
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa:3.3.0'
+
+    implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
 }

--- a/til-domain/build.gradle
+++ b/til-domain/build.gradle
@@ -3,9 +3,13 @@ bootJar.enabled = false
 jar.enabled = true
 
 dependencies {
+    // JPA
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa:3.3.0'
+
+    // Redis
     implementation 'org.springframework.boot:spring-boot-starter-data-redis:3.3.0'
 
+    // JWT
     implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'

--- a/til-domain/build.gradle
+++ b/til-domain/build.gradle
@@ -4,6 +4,7 @@ jar.enabled = true
 
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa:3.3.0'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis:3.3.0'
 
     implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'

--- a/til-domain/src/main/java/com/til/application/auth/AuthService.java
+++ b/til-domain/src/main/java/com/til/application/auth/AuthService.java
@@ -1,15 +1,19 @@
 package com.til.application.auth;
 
 import java.util.Map;
+import java.util.Objects;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
 
+import com.til.config.db.RedisManager;
 import com.til.domain.auth.dto.AuthTokenDto;
 import com.til.domain.auth.dto.AuthUserInfoDto;
+import com.til.domain.auth.enums.AuthErrorCode;
 import com.til.domain.auth.enums.TokenType;
+import com.til.domain.auth.exception.TokenInvalidException;
 import com.til.domain.auth.provider.TokenProvider;
 
 import io.jsonwebtoken.Claims;
@@ -20,19 +24,21 @@ import lombok.RequiredArgsConstructor;
 @Transactional(readOnly = true)
 public class AuthService {
 	private final TokenProvider tokenProvider;
+	private final RedisManager redisManager;
 
 	@Value("${jwt.access.expiration}")
 	private Long ACCESS_EXPIRE_DURATION;
 
 	@Value("${jwt.refresh.expiration}")
 	private Long REFRESH_EXPIRE_DURATION;
+
 	private static final String BEARER_TYPE = "Bearer";
 
 	public AuthTokenDto createToken(AuthUserInfoDto authUserInfoDto) {
 		String accessToken = generateToken(authUserInfoDto, TokenType.ACCESS);
 		String refreshToken = generateToken(authUserInfoDto, TokenType.REFRESH);
-
-		// TODO : Redis에 refresh token 저장
+		redisManager.setData(TokenType.REFRESH.name() + "_TOKEN:" + authUserInfoDto.email(), refreshToken,
+			REFRESH_EXPIRE_DURATION);
 
 		return AuthTokenDto.of(accessToken, refreshToken);
 	}
@@ -41,12 +47,19 @@ public class AuthService {
 		String refreshToken = resolveToken(bearerToken);
 		tokenProvider.validateToken(refreshToken);
 
-		// TODO : Redis에 저장된 refresh token과 비교
-
 		Claims claims = tokenProvider.parseClaims(refreshToken);
 		AuthUserInfoDto authUserInfoDto = AuthUserInfoDto.of(claims);
 
+		validateRefreshToken(authUserInfoDto.email(), refreshToken);
+
 		return createToken(authUserInfoDto);
+	}
+
+	public void validateRefreshToken(String key, String refreshToken) {
+		String redisToken = redisManager.getData(TokenType.REFRESH.name() + "_TOKEN:" + key);
+		if (!Objects.equals(refreshToken, redisToken)) {
+			throw new TokenInvalidException(AuthErrorCode.INVALID_TOKEN);
+		}
 	}
 
 	private String generateToken(AuthUserInfoDto authUserInfoDto, TokenType tokenType) {
@@ -67,4 +80,5 @@ public class AuthService {
 	private Long getExpireDuration(TokenType tokenType) {
 		return tokenType == TokenType.ACCESS ? ACCESS_EXPIRE_DURATION : REFRESH_EXPIRE_DURATION;
 	}
+
 }

--- a/til-domain/src/main/java/com/til/application/auth/AuthService.java
+++ b/til-domain/src/main/java/com/til/application/auth/AuthService.java
@@ -1,0 +1,70 @@
+package com.til.application.auth;
+
+import java.util.Map;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+
+import com.til.domain.auth.dto.AuthTokenDto;
+import com.til.domain.auth.dto.AuthUserInfoDto;
+import com.til.domain.auth.enums.TokenType;
+import com.til.domain.auth.provider.TokenProvider;
+
+import io.jsonwebtoken.Claims;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AuthService {
+	private final TokenProvider tokenProvider;
+
+	@Value("${jwt.access.expiration}")
+	private Long ACCESS_EXPIRE_DURATION;
+
+	@Value("${jwt.refresh.expiration}")
+	private Long REFRESH_EXPIRE_DURATION;
+	private static final String BEARER_TYPE = "Bearer";
+
+	public AuthTokenDto createToken(AuthUserInfoDto authUserInfoDto) {
+		String accessToken = generateToken(authUserInfoDto, TokenType.ACCESS);
+		String refreshToken = generateToken(authUserInfoDto, TokenType.REFRESH);
+
+		// TODO : Redis에 refresh token 저장
+
+		return AuthTokenDto.of(accessToken, refreshToken);
+	}
+
+	public AuthTokenDto reissueToken(String bearerToken) {
+		String refreshToken = resolveToken(bearerToken);
+		tokenProvider.validateToken(refreshToken);
+
+		// TODO : Redis에 저장된 refresh token과 비교
+
+		Claims claims = tokenProvider.parseClaims(refreshToken);
+		AuthUserInfoDto authUserInfoDto = AuthUserInfoDto.of(claims);
+
+		return createToken(authUserInfoDto);
+	}
+
+	private String generateToken(AuthUserInfoDto authUserInfoDto, TokenType tokenType) {
+		String subject = authUserInfoDto.getSubject();
+		Map<String, Object> claims = authUserInfoDto.toClaims(tokenType);
+		Long expireDuration = getExpireDuration(tokenType);
+
+		return tokenProvider.generateToken(subject, claims, expireDuration);
+	}
+
+	private String resolveToken(String bearerToken) {
+		if (StringUtils.hasText(bearerToken) & bearerToken.startsWith(BEARER_TYPE)) {
+			return bearerToken.substring(BEARER_TYPE.length() + 1);
+		}
+		return null;
+	}
+
+	private Long getExpireDuration(TokenType tokenType) {
+		return tokenType == TokenType.ACCESS ? ACCESS_EXPIRE_DURATION : REFRESH_EXPIRE_DURATION;
+	}
+}

--- a/til-domain/src/main/java/com/til/application/user/UserService.java
+++ b/til-domain/src/main/java/com/til/application/user/UserService.java
@@ -4,8 +4,10 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.til.domain.auth.dto.AuthUserInfoDto;
 import com.til.domain.common.exception.BaseException;
 import com.til.domain.user.dto.UserJoinDto;
+import com.til.domain.user.dto.UserLoginDto;
 import com.til.domain.user.enums.UserErrorCode;
 import com.til.domain.user.model.User;
 import com.til.domain.user.repository.UserRepository;
@@ -36,6 +38,16 @@ public class UserService {
 		user.setPassword(encodePassword);
 
 		userRepository.save(user);
+	}
+
+	public AuthUserInfoDto login(UserLoginDto userLoginDto) {
+		User user = userRepository.findByEmail(userLoginDto.email())
+			.orElseThrow(() -> new BaseException(UserErrorCode.NOT_FOUND_USER));
+		if (!passwordEncoder.matches(userLoginDto.password(), user.getPassword())) {
+			throw new BaseException(UserErrorCode.FAILED_LOGIN);
+		}
+
+		return AuthUserInfoDto.of(user.getEmail(), user.getNickname(), user.getRole());
 	}
 
 	public void checkNickname(String nickname) {

--- a/til-domain/src/main/java/com/til/config/db/RedisConfig.java
+++ b/til-domain/src/main/java/com/til/config/db/RedisConfig.java
@@ -1,0 +1,46 @@
+package com.til.config.db;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+@EnableRedisRepositories
+public class RedisConfig {
+	@Value("${spring.data.redis.host}")
+	private String HOST;
+
+	@Value("${spring.data.redis.port}")
+	private int PORT;
+
+	@Value("${spring.data.redis.password}")
+	private String PASSWORD;
+
+	@Bean
+	public RedisConnectionFactory redisConnectionFactory() {
+		RedisStandaloneConfiguration redisConfiguration = new RedisStandaloneConfiguration();
+		redisConfiguration.setHostName(HOST);
+		redisConfiguration.setPort(PORT);
+		redisConfiguration.setPassword(PASSWORD);
+
+		return new LettuceConnectionFactory(redisConfiguration);
+	}
+
+	@Bean
+	public RedisTemplate<String, String> redisTemplate() {
+		RedisTemplate<String, String> redisTemplate = new RedisTemplate<>();
+		redisTemplate.setConnectionFactory(redisConnectionFactory());
+		redisTemplate.setKeySerializer(new StringRedisSerializer());
+		redisTemplate.setValueSerializer(new StringRedisSerializer());
+		redisTemplate.setHashKeySerializer(new StringRedisSerializer());
+		redisTemplate.setHashValueSerializer(new StringRedisSerializer());
+
+		return redisTemplate;
+	}
+}

--- a/til-domain/src/main/java/com/til/config/db/RedisManager.java
+++ b/til-domain/src/main/java/com/til/config/db/RedisManager.java
@@ -1,0 +1,35 @@
+package com.til.config.db;
+
+import java.time.Duration;
+
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class RedisManager {
+	private final RedisTemplate<String, String> redisTemplate;
+
+	public void setData(String key, String value) {
+		redisTemplate.opsForValue().set(key, value);
+	}
+
+	public void setData(String key, String value, long duration) {
+		Duration expireDuration = Duration.ofSeconds(duration);
+		redisTemplate.opsForValue().set(key, value, expireDuration);
+	}
+
+	public String getData(String key) {
+		return redisTemplate.opsForValue().get(key);
+	}
+
+	public void deleteData(String key) {
+		redisTemplate.delete(key);
+	}
+
+	public boolean existData(String key) {
+		return Boolean.TRUE.equals(redisTemplate.hasKey(key));
+	}
+}

--- a/til-domain/src/main/java/com/til/domain/auth/dto/AuthTokenDto.java
+++ b/til-domain/src/main/java/com/til/domain/auth/dto/AuthTokenDto.java
@@ -1,0 +1,13 @@
+package com.til.domain.auth.dto;
+
+import lombok.Builder;
+
+@Builder
+public record AuthTokenDto(
+	String accessToken,
+	String refreshToken
+) {
+	public static AuthTokenDto of(String accessToken, String refreshToken) {
+		return new AuthTokenDto(accessToken, refreshToken);
+	}
+}

--- a/til-domain/src/main/java/com/til/domain/auth/dto/AuthUserInfoDto.java
+++ b/til-domain/src/main/java/com/til/domain/auth/dto/AuthUserInfoDto.java
@@ -1,0 +1,48 @@
+package com.til.domain.auth.dto;
+
+import java.util.Map;
+
+import com.til.domain.auth.enums.TokenType;
+import com.til.domain.user.model.Role;
+
+import io.jsonwebtoken.Claims;
+import lombok.Builder;
+
+@Builder
+public record AuthUserInfoDto(
+	String email,
+	String nickname,
+	Role role
+) {
+	public String getSubject() {
+		return this.email;
+	}
+
+	public Map<String, Object> toClaims(TokenType tokenType) {
+		return Map.of(
+			"nickname", this.nickname,
+			"role", this.role,
+			"tokenType", tokenType.name()
+		);
+	}
+
+	public static AuthUserInfoDto of(Claims claims) {
+		String email = claims.getSubject().toString();
+		String nickname = claims.get("nickname").toString();
+		Role role = Role.valueOf(claims.get("role").toString());
+
+		return AuthUserInfoDto.builder()
+			.email(email)
+			.nickname(nickname)
+			.role(role)
+			.build();
+	}
+
+	public static AuthUserInfoDto of(String email, String nickname, Role role) {
+		return AuthUserInfoDto.builder()
+			.email(email)
+			.nickname(nickname)
+			.role(role)
+			.build();
+	}
+}

--- a/til-domain/src/main/java/com/til/domain/auth/enums/AuthErrorCode.java
+++ b/til-domain/src/main/java/com/til/domain/auth/enums/AuthErrorCode.java
@@ -1,0 +1,21 @@
+package com.til.domain.auth.enums;
+
+import org.springframework.http.HttpStatus;
+
+import com.til.domain.common.enums.ErrorCode;
+
+import lombok.Getter;
+
+@Getter
+public enum AuthErrorCode implements ErrorCode {
+	INVALID_TOKEN("유효하지 않은 토큰입니다."),
+	EXPIRED_TOKEN("만료된 토큰입니다.");
+
+	private final HttpStatus status;
+	private final String message;
+
+	AuthErrorCode(String message) {
+		this.status = HttpStatus.UNAUTHORIZED;
+		this.message = message;
+	}
+}

--- a/til-domain/src/main/java/com/til/domain/auth/enums/TokenType.java
+++ b/til-domain/src/main/java/com/til/domain/auth/enums/TokenType.java
@@ -1,0 +1,9 @@
+package com.til.domain.auth.enums;
+
+import lombok.Getter;
+
+@Getter
+public enum TokenType {
+	ACCESS,
+	REFRESH
+}

--- a/til-domain/src/main/java/com/til/domain/auth/exception/TokenInvalidException.java
+++ b/til-domain/src/main/java/com/til/domain/auth/exception/TokenInvalidException.java
@@ -1,0 +1,12 @@
+package com.til.domain.auth.exception;
+
+import com.til.domain.common.enums.ErrorCode;
+import com.til.domain.common.exception.BaseException;
+
+public class TokenInvalidException extends BaseException {
+	private ErrorCode errorCode;
+
+	public TokenInvalidException(ErrorCode errorCode) {
+		super(errorCode);
+	}
+}

--- a/til-domain/src/main/java/com/til/domain/auth/provider/TokenProvider.java
+++ b/til-domain/src/main/java/com/til/domain/auth/provider/TokenProvider.java
@@ -1,0 +1,72 @@
+package com.til.domain.auth.provider;
+
+import java.util.Date;
+import java.util.Map;
+
+import javax.crypto.SecretKey;
+
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import com.til.domain.auth.enums.AuthErrorCode;
+import com.til.domain.auth.exception.TokenInvalidException;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.UnsupportedJwtException;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import io.jsonwebtoken.security.SignatureException;
+import lombok.extern.slf4j.Slf4j;
+
+@Component
+@Slf4j
+public class TokenProvider implements InitializingBean {
+	@Value("${jwt.secret}")
+	private String secretKey;
+
+	private SecretKey key;
+
+	@Override
+	public void afterPropertiesSet() {
+		byte[] keyBytes = Decoders.BASE64.decode(secretKey);
+		this.key = Keys.hmacShaKeyFor(keyBytes);
+	}
+
+	public String generateToken(String subject, Map<String, Object> claims, Long expireDuration) {
+		Date tokenExpireTime = makeExpireTime(expireDuration);
+
+		return Jwts.builder()
+			.subject(subject)
+			.claims(claims)
+			.expiration(tokenExpireTime)
+			.signWith(SignatureAlgorithm.HS256, secretKey)
+			.compact();
+	}
+
+	public void validateToken(String token) {
+		try {
+			Jwts.parser().verifyWith(key).build().parseSignedClaims(token);
+		} catch (MalformedJwtException | SignatureException | UnsupportedJwtException | IllegalArgumentException e) {
+			throw new TokenInvalidException(AuthErrorCode.INVALID_TOKEN);
+		} catch (ExpiredJwtException e) {
+			throw new TokenInvalidException(AuthErrorCode.EXPIRED_TOKEN);
+		}
+	}
+
+	public Claims parseClaims(String token) {
+		return Jwts.parser()
+			.verifyWith(key)
+			.build()
+			.parseSignedClaims(token)
+			.getPayload();
+	}
+
+	private Date makeExpireTime(Long expireDuration) {
+		return new Date(System.currentTimeMillis() + expireDuration);
+	}
+}

--- a/til-domain/src/main/java/com/til/domain/user/dto/UserLoginDto.java
+++ b/til-domain/src/main/java/com/til/domain/user/dto/UserLoginDto.java
@@ -1,0 +1,18 @@
+package com.til.domain.user.dto;
+
+import com.til.domain.user.model.User;
+
+import lombok.Builder;
+
+@Builder
+public record UserLoginDto(
+	String email,
+	String password
+) {
+	public User toEntity() {
+		return User.builder()
+			.email(email)
+			.password(password)
+			.build();
+	}
+}

--- a/til-domain/src/main/java/com/til/domain/user/enums/UserErrorCode.java
+++ b/til-domain/src/main/java/com/til/domain/user/enums/UserErrorCode.java
@@ -10,6 +10,7 @@ import lombok.Getter;
 public enum UserErrorCode implements ErrorCode {
 	ALREADY_EXISTS_NICKNAME(HttpStatus.BAD_REQUEST, "이미 존재하는 닉네임입니다."),
 	ALREADY_EXISTS_EMAIL(HttpStatus.BAD_REQUEST, "이미 존재하는 이메일입니다."),
+	FAILED_LOGIN(HttpStatus.BAD_REQUEST, "로그인에 실패했습니다."),
 	NOT_FOUND_USER(HttpStatus.NOT_FOUND, "해당 사용자를 찾을 수 없습니다.");
 
 	private final HttpStatus status;

--- a/til-domain/src/main/java/com/til/domain/user/enums/UserSuccessCode.java
+++ b/til-domain/src/main/java/com/til/domain/user/enums/UserSuccessCode.java
@@ -7,6 +7,7 @@ import lombok.Getter;
 @Getter
 public enum UserSuccessCode implements SuccessCode {
 	SUCCESS_JOIN("회원가입에 성공하였습니다."),
+	SUCCESS_LOGIN("로그인에 성공하였습니다."),
 	POSSIBLE_NICKNAME("사용 가능한 닉네임입니다.");
 
 	private final String message;

--- a/til-domain/src/main/java/com/til/domain/user/repository/UserRepository.java
+++ b/til-domain/src/main/java/com/til/domain/user/repository/UserRepository.java
@@ -1,5 +1,7 @@
 package com.til.domain.user.repository;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.til.domain.user.model.User;
@@ -8,4 +10,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
 	boolean existsByEmail(String email);
 
 	boolean existsByNickname(String nickname);
+
+	Optional<User> findByEmail(String email);
 }

--- a/til-domain/src/test/java/com/til/application/user/UserServiceTest.java
+++ b/til-domain/src/test/java/com/til/application/user/UserServiceTest.java
@@ -3,6 +3,8 @@ package com.til.application.user;
 import static org.assertj.core.api.AssertionsForClassTypes.*;
 import static org.mockito.BDDMockito.*;
 
+import java.util.Optional;
+
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -11,6 +13,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.til.domain.common.exception.BaseException;
 import com.til.domain.user.dto.UserJoinDto;
+import com.til.domain.user.dto.UserLoginDto;
 import com.til.domain.user.repository.UserRepository;
 import com.til.domain.user.validator.UserInfoValidator;
 
@@ -54,11 +57,31 @@ class UserServiceTest {
 		assertThat(throwable).isInstanceOf(BaseException.class);
 	}
 
+	@Test
+	void 로그인시_회원으로_등록되지_않은_정보는_예외를_던진다() {
+		// given
+		given(userRepository.findByEmail(anyString())).willReturn(Optional.empty());
+		UserLoginDto userLoginDto = createUserLoginDto();
+
+		// when
+		Throwable throwable = catchThrowable(() -> userService.login(userLoginDto));
+
+		// then
+		assertThat(throwable).isInstanceOf(BaseException.class);
+	}
+
 	private UserJoinDto createUserJoinDto() {
 		return UserJoinDto.builder()
 			.email("test@til.com")
 			.password("soma2024")
 			.nickname("선인장24")
+			.build();
+	}
+
+	private UserLoginDto createUserLoginDto() {
+		return UserLoginDto.builder()
+			.email("test@til.com")
+			.password("soma2024")
 			.build();
 	}
 }

--- a/til-domain/src/test/java/com/til/domain/auth/provider/TokenProviderTest.java
+++ b/til-domain/src/test/java/com/til/domain/auth/provider/TokenProviderTest.java
@@ -1,0 +1,106 @@
+package com.til.domain.auth.provider;
+
+import static org.assertj.core.api.AssertionsForClassTypes.*;
+
+import java.util.Date;
+import java.util.Map;
+
+import javax.crypto.SecretKey;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.til.domain.auth.exception.TokenInvalidException;
+
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+
+@ExtendWith(MockitoExtension.class)
+class TokenProviderTest {
+	@InjectMocks
+	private TokenProvider tokenProvider;
+
+	private String secretKey = "test1234".repeat(10);
+
+	@BeforeEach
+	void setUp() {
+		ReflectionTestUtils.setField(tokenProvider, "secretKey", secretKey);
+		tokenProvider.afterPropertiesSet();
+	}
+
+	@Test
+	void 유효기간이_지난_토큰을_검증하면_예외를_던진다() {
+		// given
+		String token = createExpiredToken();
+
+		// when
+		Throwable throwable = catchThrowable(() -> tokenProvider.validateToken(token));
+
+		// then
+		assertThat(throwable).isInstanceOf(TokenInvalidException.class);
+	}
+
+	@Test
+	void 시크릿키가_문제있는_토큰을_검증하면_예외를_던진다() {
+		// given
+		String token = createInvalidToken();
+
+		// when
+		Throwable throwable = catchThrowable(() -> tokenProvider.validateToken(token));
+
+		// then
+		assertThat(throwable).isInstanceOf(TokenInvalidException.class);
+	}
+
+	@Test
+	void 유효기간이_지나지_않고_시크릿키가_문제없는_토큰을_검증하면_예외를_던지지_않는다() {
+		// given
+		String token = createValidToken();
+
+		// when
+		Throwable throwable = catchThrowable(() -> tokenProvider.validateToken(token));
+
+		// then
+		assertThat(throwable).isNull();
+	}
+
+	private String createExpiredToken() {
+		return Jwts.builder()
+			.subject("test@til.com")
+			.claims(null)
+			.expiration(new Date(System.currentTimeMillis() - 60000))
+			.signWith(getSecretKey())
+			.compact();
+	}
+
+	private String createInvalidToken() {
+		return Jwts.builder()
+			.subject("test@til.com")
+			.claims(null)
+			.expiration(new Date(System.currentTimeMillis() + 1000000))
+			.signWith(getWrongSecretKey())
+			.compact();
+	}
+
+	private String createValidToken() {
+		return Jwts.builder()
+			.subject("test@til.com")
+			.claims(Map.of("nickname", "test", "role", "USER", "tokenType", "ACCESS"))
+			.expiration(new Date(System.currentTimeMillis() + 1000000))
+			.signWith(getSecretKey())
+			.compact();
+	}
+
+	private SecretKey getSecretKey() {
+		return Keys.hmacShaKeyFor(Decoders.BASE64.decode(secretKey));
+	}
+
+	private SecretKey getWrongSecretKey() {
+		return Keys.hmacShaKeyFor(Decoders.BASE64.decode("wrong".repeat(10)));
+	}
+}


### PR DESCRIPTION
## 이슈 번호(링크)

[TIL-26](https://soma-til.atlassian.net/browse/TIL-26)

<br>

## 개요
- Redis 연동
- 로그인 API 기능 구현

<br>

## 내용
- JWT 토큰 발급 및 재발급 기능
  - TokenProvider에서 JWT토큰 생성/검증/파싱을 위한 기본 로직 구성
  - AuthService에서는 TIL 인증/인가를 위한 로직 구성
- Redis 연동
  - 로컬 개발 환경을 위한 도커 파일에 redis 관련 설정 추가
  - 도메인 모듈에 redis 연동 관련 설정
  - redis 데이터 접근 및 처리를 위한 RedisManager 생성
- 로그인 API : [API 문서](https://soma-til.notion.site/ae83a76af77949b8b08f2013a0c7ec9c)
  - 로그인 성공시 access 토큰과 refresh 토큰 발급
  - refresh 토큰은 redis에 `REFRESH_{사용자이메일}:{refresh 토큰 값}` 형태로 저장됨

<br>

## 리뷰어한테 할 말
- 사용자 인가를 위한 JWT 필터(or 인터셉터)는 Spring security 부분에 적용하려고 하는데
   작업 크기가 이번 task에 합쳐서 진행하기에는 큰 것 같아서 별도 task로 분리해서 작업하도록 하겠습니다!

[TIL-26]: https://soma-til.atlassian.net/browse/TIL-26?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ