### PR TITLE
[TIL-47] 사용자 인가 로직 구현

### DIFF
--- a/til-api/build.gradle
+++ b/til-api/build.gradle
@@ -3,5 +3,8 @@ dependencies {
 
     implementation 'org.springframework.boot:spring-boot-starter-web:3.3.0'
 
+    // JWT
+    implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
+
     runtimeOnly 'com.mysql:mysql-connector-j:8.4.0'
 }

--- a/til-api/src/main/java/com/til/common/annotation/CurrentUser.java
+++ b/til-api/src/main/java/com/til/common/annotation/CurrentUser.java
@@ -1,0 +1,11 @@
+package com.til.common.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface CurrentUser {
+}

--- a/til-api/src/main/java/com/til/config/WebConfig.java
+++ b/til-api/src/main/java/com/til/config/WebConfig.java
@@ -1,15 +1,25 @@
 package com.til.config;
 
+import java.util.List;
+
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
+import com.til.config.resolver.CurrentUserResolver;
+
+import lombok.RequiredArgsConstructor;
+
 @Configuration
-public class WebConfig {
+@RequiredArgsConstructor
+public class WebConfig implements WebMvcConfigurer {
 	@Value("${cors.allowed.origin}")
 	private String ALLOWED_ORIGIN_URL;
+
+	private final CurrentUserResolver currentUserResolver;
 
 	@Bean
 	public WebMvcConfigurer corsConfigurer() {
@@ -23,5 +33,9 @@ public class WebConfig {
 					.allowCredentials(true);
 			}
 		};
+	}
+
+	public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+		resolvers.add(currentUserResolver);
 	}
 }

--- a/til-api/src/main/java/com/til/config/errorhandling/GlobalExceptionHandler.java
+++ b/til-api/src/main/java/com/til/config/errorhandling/GlobalExceptionHandler.java
@@ -1,12 +1,11 @@
 package com.til.config.errorhandling;
 
-import java.nio.file.AccessDeniedException;
-
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -96,7 +95,7 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 
 	@ExceptionHandler(Exception.class)
 	protected ResponseEntity<ErrorResponse> handleAllException(final Exception ex) {
-		log.error("Exception: {}", ex.getMessage());
+		log.error("Exception: {} {}", ex.getClass(), ex.getMessage());
 		ErrorResponse response = ErrorResponse.of(BaseErrorCode.INTERNAL_SERVER_ERROR);
 
 		return ResponseEntity

--- a/til-api/src/main/java/com/til/config/resolver/CurrentUserResolver.java
+++ b/til-api/src/main/java/com/til/config/resolver/CurrentUserResolver.java
@@ -1,0 +1,42 @@
+package com.til.config.resolver;
+
+import java.util.Optional;
+
+import org.springframework.core.MethodParameter;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+import com.til.application.user.UserService;
+import com.til.common.annotation.CurrentUser;
+import com.til.domain.common.enums.BaseErrorCode;
+import com.til.domain.common.exception.BaseException;
+import com.til.domain.user.dto.UserInfoDto;
+
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class CurrentUserResolver implements HandlerMethodArgumentResolver {
+	private final UserService userService;
+
+	@Override
+	public boolean supportsParameter(MethodParameter parameter) {
+		return parameter.hasParameterAnnotation(CurrentUser.class)
+			&& parameter.getParameterType().equals(UserInfoDto.class);
+	}
+
+	@Override
+	public Object resolveArgument(@NonNull MethodParameter parameter, ModelAndViewContainer mavContainer,
+		@NonNull NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
+		return Optional.ofNullable(SecurityContextHolder.getContext().getAuthentication())
+			.filter(Authentication::isAuthenticated)
+			.map(auth -> userService.getUserInfo(auth.getPrincipal().toString()))
+			.orElseThrow(() -> new BaseException(BaseErrorCode.UNAUTHORIZED));
+	}
+}

--- a/til-api/src/main/java/com/til/config/resolver/CurrentUserResolver.java
+++ b/til-api/src/main/java/com/til/config/resolver/CurrentUserResolver.java
@@ -13,8 +13,6 @@ import org.springframework.web.method.support.ModelAndViewContainer;
 
 import com.til.application.user.UserService;
 import com.til.common.annotation.CurrentUser;
-import com.til.domain.common.enums.BaseErrorCode;
-import com.til.domain.common.exception.BaseException;
 import com.til.domain.user.dto.UserInfoDto;
 
 import lombok.NonNull;
@@ -36,7 +34,6 @@ public class CurrentUserResolver implements HandlerMethodArgumentResolver {
 		@NonNull NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
 		return Optional.ofNullable(SecurityContextHolder.getContext().getAuthentication())
 			.filter(Authentication::isAuthenticated)
-			.map(auth -> userService.getUserInfo(auth.getPrincipal().toString()))
-			.orElseThrow(() -> new BaseException(BaseErrorCode.UNAUTHORIZED));
+			.map(auth -> userService.getUserInfo(auth.getPrincipal().toString()));
 	}
 }

--- a/til-api/src/main/java/com/til/config/security/AuthenticationDeniedHandler.java
+++ b/til-api/src/main/java/com/til/config/security/AuthenticationDeniedHandler.java
@@ -1,0 +1,25 @@
+package com.til.config.security;
+
+import java.io.IOException;
+
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerExceptionResolver;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class AuthenticationDeniedHandler implements AccessDeniedHandler {
+	private final HandlerExceptionResolver handlerExceptionResolver;
+
+	@Override
+	public void handle(HttpServletRequest request, HttpServletResponse response,
+		AccessDeniedException accessDeniedException) throws IOException, ServletException {
+		handlerExceptionResolver.resolveException(request, response, null, accessDeniedException);
+	}
+}

--- a/til-api/src/main/java/com/til/config/security/AuthenticationFilter.java
+++ b/til-api/src/main/java/com/til/config/security/AuthenticationFilter.java
@@ -1,0 +1,103 @@
+package com.til.config.security;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import org.springframework.http.HttpMethod;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.util.AntPathMatcher;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.til.common.response.ApiStatus;
+import com.til.domain.auth.provider.TokenProvider;
+import com.til.domain.common.enums.BaseErrorCode;
+import com.til.domain.user.model.Role;
+
+import io.jsonwebtoken.Claims;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class AuthenticationFilter extends OncePerRequestFilter {
+	private final TokenProvider tokenProvider;
+	private final AntPathMatcher pathMatcher = new AntPathMatcher();
+	private final ObjectMapper objectMapper = new ObjectMapper();
+
+	private static final String AUTHORIZATION_HEADER = "Authorization";
+	private static final String BEARER_TYPE = "Bearer";
+
+	@Override
+	protected boolean shouldNotFilter(HttpServletRequest request) {
+		String path = request.getRequestURI();
+		return Stream.of(PathPermission.getPublicPath())
+			.anyMatch(pattern -> pathMatcher.match(pattern, path));
+	}
+
+	@Override
+	protected void doFilterInternal(HttpServletRequest request,
+		@NonNull HttpServletResponse response, @NonNull FilterChain filterChain) throws ServletException, IOException {
+		log.debug("[REQUEST_INFO] ({}) URI={}", request.getMethod(), request.getRequestURI());
+
+		if (request.getMethod().equals(HttpMethod.OPTIONS.name())) {
+			filterChain.doFilter(request, response);
+			return;
+		}
+
+		String token = resolveToken(request);
+		if (token == null) {
+			handleException(response);
+			return;
+		}
+
+		try {
+			tokenProvider.validateToken(token);
+		} catch (Exception e) {
+			handleException(response);
+			return;
+		}
+
+		Authentication auth = createAuthentication(tokenProvider.parseClaims(token));
+		SecurityContextHolder.getContext().setAuthentication(auth);
+		filterChain.doFilter(request, response);
+	}
+
+	private String resolveToken(HttpServletRequest request) {
+		return Optional.ofNullable(request.getHeader(AUTHORIZATION_HEADER))
+			.filter(token -> token.startsWith(BEARER_TYPE))
+			.map(token -> token.substring(BEARER_TYPE.length() + 1))
+			.orElse(null);
+	}
+
+	private UsernamePasswordAuthenticationToken createAuthentication(Claims claims) {
+		String email = claims.getSubject();
+		Role role = Role.valueOf(claims.get("role").toString());
+		return new UsernamePasswordAuthenticationToken(email, null, getAuthorities(role));
+	}
+
+	private Collection<? extends GrantedAuthority> getAuthorities(Role role) {
+		Collection<GrantedAuthority> collectors = new ArrayList<>();
+		collectors.add(() -> "ROLE_" + role.name());
+		return collectors;
+	}
+
+	private void handleException(HttpServletResponse response) throws IOException {
+		response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+		response.setContentType("application/json; charset=UTF-8");
+		response.getWriter().write(objectMapper.writeValueAsString(ApiStatus.of(BaseErrorCode.UNAUTHORIZED)));
+	}
+}

--- a/til-api/src/main/java/com/til/config/security/PathPermission.java
+++ b/til-api/src/main/java/com/til/config/security/PathPermission.java
@@ -1,0 +1,11 @@
+package com.til.config.security;
+
+public class PathPermission {
+	public static String[] getPublicPath() {
+		return new String[] {"/user/**"};
+	}
+
+	public static String[] getAdminPath() {
+		return new String[] {};
+	}
+}

--- a/til-api/src/main/java/com/til/config/security/SecurityConfig.java
+++ b/til-api/src/main/java/com/til/config/security/SecurityConfig.java
@@ -4,12 +4,14 @@ import static org.springframework.security.config.http.SessionCreationPolicy.*;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
-import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+import com.til.domain.user.model.Role;
 
 import lombok.RequiredArgsConstructor;
 
@@ -17,7 +19,8 @@ import lombok.RequiredArgsConstructor;
 @EnableWebSecurity
 @RequiredArgsConstructor
 public class SecurityConfig {
-	private final UserDetailsService userDetailsService;
+	private final AuthenticationFilter authenticationFilter;
+	private final AuthenticationDeniedHandler authenticationDeniedHandler;
 
 	@Bean
 	public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
@@ -25,12 +28,15 @@ public class SecurityConfig {
 			.formLogin(AbstractHttpConfigurer::disable)
 			.httpBasic(AbstractHttpConfigurer::disable)
 			.csrf(AbstractHttpConfigurer::disable)
-			.headers((headers) -> headers.frameOptions((frameOptions) -> frameOptions.disable()))
+			.headers((headers) -> headers.frameOptions(HeadersConfigurer.FrameOptionsConfig::disable))
 			.sessionManagement(session -> session.sessionCreationPolicy(STATELESS))
 			.authorizeHttpRequests((request) -> request
-				.requestMatchers(HttpMethod.GET, "/user/**").permitAll()
-				.requestMatchers(HttpMethod.POST, "/user/**").permitAll()
-				.anyRequest().authenticated());
+				.requestMatchers(PathPermission.getPublicPath()).permitAll()
+				.requestMatchers(PathPermission.getAdminPath()).hasRole(Role.ADMIN.name())
+				.anyRequest().authenticated()
+			)
+			.exceptionHandling((except) -> except.accessDeniedHandler(authenticationDeniedHandler))
+			.addFilterBefore(authenticationFilter, UsernamePasswordAuthenticationFilter.class);
 
 		return http.build();
 	}

--- a/til-domain/src/main/java/com/til/application/auth/AuthService.java
+++ b/til-domain/src/main/java/com/til/application/auth/AuthService.java
@@ -71,7 +71,7 @@ public class AuthService {
 	}
 
 	private String resolveToken(String bearerToken) {
-		if (StringUtils.hasText(bearerToken) & bearerToken.startsWith(BEARER_TYPE)) {
+		if (StringUtils.hasText(bearerToken) && bearerToken.startsWith(BEARER_TYPE)) {
 			return bearerToken.substring(BEARER_TYPE.length() + 1);
 		}
 		return null;
@@ -80,5 +80,4 @@ public class AuthService {
 	private Long getExpireDuration(TokenType tokenType) {
 		return tokenType == TokenType.ACCESS ? ACCESS_EXPIRE_DURATION : REFRESH_EXPIRE_DURATION;
 	}
-
 }

--- a/til-domain/src/main/java/com/til/application/user/UserService.java
+++ b/til-domain/src/main/java/com/til/application/user/UserService.java
@@ -41,7 +41,7 @@ public class UserService {
 	}
 
 	public AuthUserInfoDto login(UserLoginDto userLoginDto) {
-		User user = getUserByEmail(userLoginDto.email());
+		User user = userRepository.getByEmail(userLoginDto.email());
 		if (!passwordEncoder.matches(userLoginDto.password(), user.getPassword())) {
 			throw new BaseException(UserErrorCode.FAILED_LOGIN);
 		}
@@ -50,13 +50,8 @@ public class UserService {
 	}
 
 	public UserInfoDto getUserInfo(String email) {
-		User user = getUserByEmail(email);
+		User user = userRepository.getByEmail(email);
 		return UserInfoDto.of(user);
-	}
-
-	private User getUserByEmail(String email) {
-		return userRepository.findByEmail(email)
-			.orElseThrow(() -> new BaseException(UserErrorCode.NOT_FOUND_USER));
 	}
 
 	public void checkNickname(String nickname) {

--- a/til-domain/src/main/java/com/til/domain/user/dto/UserInfoDto.java
+++ b/til-domain/src/main/java/com/til/domain/user/dto/UserInfoDto.java
@@ -1,0 +1,20 @@
+package com.til.domain.user.dto;
+
+import com.til.domain.user.model.User;
+
+import lombok.Builder;
+
+@Builder
+public record UserInfoDto(
+	Long id,
+	String email,
+	String nickname
+) {
+	public static UserInfoDto of(User user) {
+		return UserInfoDto.builder()
+			.id(user.getId())
+			.email(user.getEmail())
+			.nickname(user.getNickname())
+			.build();
+	}
+}

--- a/til-domain/src/main/java/com/til/domain/user/repository/UserRepository.java
+++ b/til-domain/src/main/java/com/til/domain/user/repository/UserRepository.java
@@ -4,6 +4,8 @@ import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import com.til.domain.common.exception.BaseException;
+import com.til.domain.user.enums.UserErrorCode;
 import com.til.domain.user.model.User;
 
 public interface UserRepository extends JpaRepository<User, Long> {
@@ -12,4 +14,8 @@ public interface UserRepository extends JpaRepository<User, Long> {
 	boolean existsByNickname(String nickname);
 
 	Optional<User> findByEmail(String email);
+
+	default User getByEmail(String email) {
+		return findByEmail(email).orElseThrow(() -> new BaseException(UserErrorCode.NOT_FOUND_USER));
+	}
 }

--- a/til-domain/src/test/java/com/til/application/user/UserServiceTest.java
+++ b/til-domain/src/test/java/com/til/application/user/UserServiceTest.java
@@ -3,8 +3,6 @@ package com.til.application.user;
 import static org.assertj.core.api.AssertionsForClassTypes.*;
 import static org.mockito.BDDMockito.*;
 
-import java.util.Optional;
-
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -60,7 +58,7 @@ class UserServiceTest {
 	@Test
 	void 로그인시_회원으로_등록되지_않은_정보는_예외를_던진다() {
 		// given
-		given(userRepository.findByEmail(anyString())).willReturn(Optional.empty());
+		given(userRepository.getByEmail(anyString())).willThrow(BaseException.class);
 		UserLoginDto userLoginDto = createUserLoginDto();
 
 		// when


### PR DESCRIPTION
## 이슈 번호(링크)

[TIL-47](https://soma-til.atlassian.net/browse/TIL-47)

<br>

## 개요
- 사용자 인가 로직(with Spring Security)
- 사용자 정보 가져오는 어노테이션 생성

<br>

## 내용
- 사용자 인가 로직
  - AuthenticationFilter 를 통해 사용자가 Authorization 헤더에 넣은 토큰 값을 검증
  - 권한이 없는 접근에 대해서는 AuthenticationDeniedHandler에서 처리
  - PathPermission에는 전체/회원/관리자 권한별 접근 가능한 경로 모아둠
    ```java
       // Security에 적용시
       .requestMatchers(PathPermission.getPublicPath()).permitAll() // 전체 공개
       .requestMatchers(PathPermission.getAdminPath()).hasRole(Role.ADMIN.name()) // 관리자만 접근 가능
    ```

- `@CurrentUser` : 사용자 정보 가져오는 어노테이션
   아래와 같이 컨트롤러에서 CurrentUser 사용하면 UserInfoDto에 사용자 정보(id, email, nickname) 불러옴
   ```java
   // Example
   @GetMapping("/test2/admin")
   public ApiResponse<Object> test(@CurrentUser UserInfoDto userInfo) {
       ....
       return ApiResponse.ok();
   }
   ```
- AuthService 잘못된 조건 연산자 수정(& → &&)

<br>

## 리뷰어한테 할 말
- `@CurrentUser`에 가져온 정보는 임의로 제가 필요하다고 생각하는 정보만 선택했습니다. 추후에 필요에 따라 추가될 수도 일부 정보는 제외될 수도 있을 것 같습니다.


[TIL-47]: https://soma-til.atlassian.net/browse/TIL-47?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ