### PR TITLE
[TIL-38] 프론트 연동을 위한 CORS 설정

### DIFF
--- a/til-api/src/main/java/com/til/config/WebConfig.java
+++ b/til-api/src/main/java/com/til/config/WebConfig.java
@@ -1,5 +1,6 @@
 package com.til.config;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
@@ -7,6 +8,8 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
 public class WebConfig {
+	@Value("${cors.allowed.origin}")
+	private String ALLOWED_ORIGIN_URL;
 
 	@Bean
 	public WebMvcConfigurer corsConfigurer() {
@@ -14,8 +17,8 @@ public class WebConfig {
 			@Override
 			public void addCorsMappings(CorsRegistry registry) {
 				registry.addMapping("/**")
-					.allowedOrigins("http://localhost:3000")
-					.allowedMethods("GET", "POST", "PUT", "DELETE")
+					.allowedOrigins(ALLOWED_ORIGIN_URL)
+					.allowedMethods("GET", "POST", "PUT", "DELETE", "PATCH")
 					.allowedHeaders("*")
 					.allowCredentials(true);
 			}

--- a/til-api/src/main/java/com/til/config/WebConfig.java
+++ b/til-api/src/main/java/com/til/config/WebConfig.java
@@ -1,0 +1,24 @@
+package com.til.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig {
+
+	@Bean
+	public WebMvcConfigurer corsConfigurer() {
+		return new WebMvcConfigurer() {
+			@Override
+			public void addCorsMappings(CorsRegistry registry) {
+				registry.addMapping("/**")
+					.allowedOrigins("http://localhost:3000")
+					.allowedMethods("GET", "POST", "PUT", "DELETE")
+					.allowedHeaders("*")
+					.allowCredentials(true);
+			}
+		};
+	}
+}

--- a/til-api/src/main/resources/application.yml
+++ b/til-api/src/main/resources/application.yml
@@ -25,3 +25,6 @@ jwt:
   refresh:
     expiration: 1209600000 # 14 days(1000 * 60 * 60 * 24 * 14)
 
+cors:
+  allowed:
+    origin: http://localhost:3000


### PR DESCRIPTION
## 이슈 번호(링크)

[TIL-38](https://soma-til.atlassian.net/browse/TIL-38)

<br>

## 개요

- 프론트 연동을 위한 CORS 설정 

<br>

## 내용

- `/**` 경로에 대해 `http://localhost:3000`에서 오는 모든 요청을 허용하도록 Webconfig 파일 추가 

<br>

## 리뷰어한테 할 말

- Test를 위한 controller는 올리지 않고, 프론트에서 접근가능하도록 설정만 했습니다. 


[TIL-38]: https://soma-til.atlassian.net/browse/TIL-38?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ