### PR TITLE
[TIL-53] gradle 빌드 테스트 CI workflow 추가

### DIFF
--- a/.github/workflows/ci-build-test.yml
+++ b/.github/workflows/ci-build-test.yml
@@ -1,0 +1,41 @@
+name: "[CI] Gradle Build and Test"
+
+on:
+  pull_request:
+    branches: [ dev ]
+
+permissions:
+  checks: write
+  pull-requests: write
+
+jobs:
+  gradle-build-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Source Code
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.TOKEN }}
+          submodules: true
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'corretto'
+
+      - name: Grant Execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Build with Gradle
+        run: ./gradlew build -Pprofile=${{ secrets.PROFILE }} --exclude-task test --parallel
+
+      - name: Test with Gradle
+        run: ./gradlew test -Pprofile=${{ secrets.PROFILE }}  --parallel
+
+      - name: When Test Fail, Comment on PR with Test Report
+        uses: mikepenz/action-junit-report@v4
+        if: always()
+        with:
+          report_paths: '**/build/test-results/test/TEST-*.xml'
+          token: ${{ secrets.TOKEN }}


### PR DESCRIPTION
## 이슈 번호(링크)

[TIL-53](https://soma-til.atlassian.net/browse/TIL-53)

<br>

## 개요
- gradle 빌드 테스트 CI workflow 작성

<br>

## 내용
- CI 구성
  - 빌드 진행
  - 테스트 진행
  - 테스트 실패 시, 실패한 코드 라인에 Check 코멘트 등록하는 액션 연동

<br>

## 리뷰어한테 할 말
- gradle 프로젝트 빌드 및 테스트에 대한 ci만 구성하였으며 lint 검증은 해당 task에 포함되지 않는 영역입니다!
- PR Merge 룰에도 추가해두었습니다!
  ![image](https://github.com/user-attachments/assets/d411cc8d-05cc-4d6e-84f5-4d9f371362a7)



[TIL-53]: https://soma-til.atlassian.net/browse/TIL-53?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ