### PR TITLE
[TIL-71] 불필요한 toString() 호출 제거

### DIFF
--- a/til-domain/src/main/java/com/til/domain/auth/dto/AuthUserInfoDto.java
+++ b/til-domain/src/main/java/com/til/domain/auth/dto/AuthUserInfoDto.java
@@ -28,7 +28,7 @@ public record AuthUserInfoDto(
     }
 
     public static AuthUserInfoDto of(Claims claims) {
-        String email = claims.getSubject().toString();
+        String email = claims.getSubject();
         String nickname = claims.get("nickname").toString();
         Role role = Role.valueOf(claims.get("role").toString());
 


### PR DESCRIPTION
## 이슈 번호(링크)

[TIL-71](https://soma-til.atlassian.net/browse/TIL-71)

<br>

## 개요
불필요한 toString() 호출 제거

<br>

## 내용
- https://github.com/SOMA-TIL/TIL-Backend/pull/8 피드백 반영하여
  AuthUserInfoDto 클래스 內 불필요한 toString() 호출 제거


<br>

## 리뷰어한테 할 말
😀


[TIL-71]: https://soma-til.atlassian.net/browse/TIL-71?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ