### PR TITLE
[TIL-39] 개발 환경별 logging 설정 적용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,6 +51,10 @@ subprojects {
         compileOnly {
             extendsFrom annotationProcessor
         }
+
+        configureEach {
+            exclude group: 'org.springframework.boot', module: 'spring-boot-starter-logging'
+        }
     }
 
     repositories {
@@ -61,6 +65,9 @@ subprojects {
         implementation 'org.springframework.boot:spring-boot-starter'
         implementation 'org.springframework.boot:spring-boot-starter-validation'
         implementation 'org.springframework.boot:spring-boot-starter-security:3.3.0'
+
+        implementation 'org.springframework.boot:spring-boot-starter-log4j2'
+        implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml'
 
         compileOnly 'org.projectlombok:lombok'
         annotationProcessor 'org.projectlombok:lombok'
@@ -85,6 +92,7 @@ subprojects {
             resources {
                 srcDir "${rootProject.projectDir}/configs/${project.name.split('-')[1]}"
                 srcDir "${rootProject.projectDir}/db"
+                srcDir "${rootProject.projectDir}/log4j2"
             }
         }
     }

--- a/log4j2/log4j2-dev.yml
+++ b/log4j2/log4j2-dev.yml
@@ -1,0 +1,54 @@
+configuration:
+  name: til-dev
+
+  springProfile:
+    name: dev
+
+    properties:
+      property:
+        - name: "log-path"
+          value: "./log4j2/logs"
+        - name: "charset-UTF-8"
+          value: "UTF-8"
+        - name: "file-pattern"
+          value: "%d %p [%t] %C{1.}: %m%n"
+        - name: "console-pattern"
+          value: "%black{%d} %clr{%-5level} %magenta{[%t]} %cyan{%C}: %msg%n%throwable"
+
+    appenders:
+      console:
+        - name: console-appender
+          target: SYSTEM_OUT
+          patternLayout:
+            pattern: ${console-pattern}
+
+      rollingFile:
+        - name: rolling-file-appender
+          fileName: ${log-path}/dev.log
+          filePattern: "${log-path}/archive/dev_%d{yyyy-MM-dd}_%i.log.gz"
+          patternLayout:
+            charset: ${charset-UTF-8}
+            pattern: ${file-pattern}
+          policies:
+            SizeBasedTriggeringPolicy:
+              size: "100MB"
+            TimeBasedTriggeringPolicy:
+              interval: "1"
+          DefaultRollOverStrategy:
+            max: "30"
+            fileIndex: "max"
+
+    loggers:
+      root:
+        level: INFO
+        appenderRef:
+          - ref: console-appender
+          - ref: rolling-file-appender
+
+      logger:
+        - name: com.til
+          additivity: "false"
+          level: DEBUG
+          appenderRef:
+            - ref: console-appender
+            - ref: rolling-file-appender

--- a/log4j2/log4j2-local.yml
+++ b/log4j2/log4j2-local.yml
@@ -1,0 +1,30 @@
+configuration:
+  name: til-local
+
+  springProfile:
+    name: local
+
+    properties:
+      property:
+        - name: "console-pattern"
+          value: "%black{%d} %clr{%-5level} %magenta{[%t]} %cyan{%C}: %msg%n%throwable"
+
+    appenders:
+      console:
+        - name: console-appender
+          target: SYSTEM_OUT
+          patternLayout:
+            pattern: ${console-pattern}
+
+    loggers:
+      root:
+        level: INFO
+        appenderRef:
+          - ref: console-appender
+
+      logger:
+        - name: com.til
+          additivity: "false"
+          level: DEBUG
+          appenderRef:
+            - ref: console-appender

--- a/log4j2/log4j2-prod.yml
+++ b/log4j2/log4j2-prod.yml
@@ -1,0 +1,38 @@
+configuration:
+  name: til-prod
+
+  springProfile:
+    name: prod
+
+    properties:
+      property:
+        - name: "log-path"
+          value: "./log4j2/logs"
+        - name: "charset-UTF-8"
+          value: "UTF-8"
+        - name: "file-pattern"
+          value: "%d %p [%t] %C{1.}: %m%n"
+
+    appenders:
+      rollingFile:
+        - name: rolling-file-appender
+          fileName: ${log-path}/prod.log
+          filePattern: "${log-path}/archive/prod_%d{yyyy-MM-dd}_%i.log.gz"
+          patternLayout:
+            charset: ${charset-UTF-8}
+            pattern: ${file-pattern}
+          policies:
+            SizeBasedTriggeringPolicy:
+              size: "100MB"
+            TimeBasedTriggeringPolicy:
+              interval: "1"
+          DefaultRollOverStrategy:
+            max: "30"
+            fileIndex: "max"
+
+    loggers:
+      root:
+        level: ERROR
+        appenderRef:
+          - ref: console-appender
+          - ref: rolling-file-appender

--- a/log4j2/log4j2-test.yml
+++ b/log4j2/log4j2-test.yml
@@ -1,0 +1,30 @@
+configuration:
+  name: til-test
+
+  springProfile:
+    name: test
+
+    properties:
+      property:
+        - name: "console-pattern"
+          value: "%black{%d} %clr{%-5level} %magenta{[%t]} %cyan{%C}: %msg%n%throwable"
+
+    appenders:
+      console:
+        - name: console-appender
+          target: SYSTEM_OUT
+          patternLayout:
+            pattern: ${console-pattern}
+
+    loggers:
+      root:
+        level: INFO
+        appenderRef:
+          - ref: console-appender
+
+      logger:
+        - name: com.til
+          additivity: "false"
+          level: DEBUG
+          appenderRef:
+            - ref: console-appender


### PR DESCRIPTION
## 이슈 번호(링크)

[TIL-39](https://soma-til.atlassian.net/browse/TIL-39)

<br>

## 개요

- 개발 환경별 logging 설정 적용

<br>

## 내용
![1](https://github.com/user-attachments/assets/a33729da-9462-42c2-ae41-338fcec5b0c3)
- 프로젝트에 로깅 적용
- 로깅 관련 의존성 추가
- 서브 모듈 내부의 설정파일에 로깅을 위한 설정 추가
- 각 환경별 설정 파일 작성


<br>

## 리뷰어한테 할 말
하단 프로젝트 로깅 적용 문서 내용에 로깅 전략에 대해 더 자세히 작성해봤습니다!

참고 문서
- [프로젝트 로깅](https://soma-til.notion.site/d4da8ab20ebe4256995d7f788410bbad?pvs=4)
- [프로젝트 로깅 적용](https://soma-til.notion.site/fba63438c5ad4650960fc9811977e830?pvs=4)



[TIL-39]: https://soma-til.atlassian.net/browse/TIL-39?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ