### PR TITLE
[TIL-76] 백엔드-프론트 연동 CORS 오류 수정

### DIFF
--- a/til-api/src/main/java/com/til/config/WebConfig.java
+++ b/til-api/src/main/java/com/til/config/WebConfig.java
@@ -29,7 +29,7 @@ public class WebConfig implements WebMvcConfigurer {
             @Override
             public void addCorsMappings(CorsRegistry registry) {
                 registry.addMapping("/**")
-                    .allowedOrigins(ALLOWED_ORIGIN_URL)
+                    .allowedOriginPatterns(ALLOWED_ORIGIN_URL)
                     .allowedMethods("GET", "POST", "PUT", "DELETE", "PATCH")
                     .allowedHeaders("*")
                     .allowCredentials(true);


### PR DESCRIPTION
## 이슈 번호(링크)

[TIL-76](https://soma-til.atlassian.net/browse/TIL-76)

<br>

## 개요
백엔드-프론트 연동 CORS 오류 수정
- 문제 상황 : 개발 서버의 백엔드 api와 로컬 프론트 연동시 cors 에러 발생


<br>

## 내용
- 개발 서버의 백엔드 api와 로컬 프론트 연동이 가능할 수 있도록 설정 완료 (`*` 넣어도 에러 발생하지 않음)
- 원인 : allowedOrigin은 특정한 도메인만 받을 수 있어서 *이 허용되지 않음
- 해결 : allowedOrigin → allowedOriginPatterns 로 변경
<br>

## 리뷰어한테 할 말
- 참고
  - https://github.com/spring-projects/spring-framework/issues/26111#issuecomment-729805112


[TIL-76]: https://soma-til.atlassian.net/browse/TIL-76?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ