### PR TITLE
[TIL-83] 토큰 재발급 API 구현

### DIFF
--- a/til-api/src/main/java/com/til/controller/auth/AuthController.java
+++ b/til-api/src/main/java/com/til/controller/auth/AuthController.java
@@ -1,0 +1,30 @@
+package com.til.controller.auth;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.til.application.auth.AuthService;
+import com.til.common.response.ApiResponse;
+import com.til.controller.auth.response.AuthTokenResponse;
+import com.til.domain.auth.dto.AuthTokenDto;
+import com.til.domain.auth.enums.AuthSuccessCode;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/auth")
+public class AuthController {
+
+    public static final String AUTHORIZATION_HEADER = "Authorization";
+
+    private final AuthService authService;
+
+    @GetMapping("/reissue")
+    public ApiResponse<AuthTokenResponse> reissue(@RequestHeader(AUTHORIZATION_HEADER) String token) {
+        AuthTokenDto authTokenDto = authService.reissueToken(token);
+        return ApiResponse.ok(AuthSuccessCode.SUCCESS_REISSUE, AuthTokenResponse.of(authTokenDto));
+    }
+}

--- a/til-api/src/main/java/com/til/controller/auth/response/AuthTokenResponse.java
+++ b/til-api/src/main/java/com/til/controller/auth/response/AuthTokenResponse.java
@@ -1,0 +1,12 @@
+package com.til.controller.auth.response;
+
+import com.til.domain.auth.dto.AuthTokenDto;
+
+public record AuthTokenResponse(
+                                AuthTokenDto token
+) {
+
+    public static AuthTokenResponse of(AuthTokenDto token) {
+        return new AuthTokenResponse(token);
+    }
+}

--- a/til-domain/src/main/java/com/til/domain/auth/enums/AuthSuccessCode.java
+++ b/til-domain/src/main/java/com/til/domain/auth/enums/AuthSuccessCode.java
@@ -1,0 +1,16 @@
+package com.til.domain.auth.enums;
+
+import com.til.domain.common.enums.SuccessCode;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public enum AuthSuccessCode implements SuccessCode {
+
+    SUCCESS_REISSUE("토큰 재발급에 성공하였습니다.");
+
+    private final String message;
+}


### PR DESCRIPTION
## 이슈 번호(링크)

[TIL-83](https://soma-til.atlassian.net/browse/TIL-83)

<br>

## 개요
토큰 재발급 API 구현

<br>

## 내용
- Authorization Header에 유효한 refresh 토큰 정보를 담아 요청할 경우
   refresh토큰과 access 토큰을 재발급
- 참고 : [토큰 재발급 API 문서](https://soma-til.notion.site/a2e5640f6dd64a6a8f8d121e55c9073c)
<br>

## 리뷰어한테 할 말
😀

[TIL-83]: https://soma-til.atlassian.net/browse/TIL-83?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ