### PR TITLE
[TIL-70] final modifier를 적용하여 수정 불가능하도록 변경

### DIFF
--- a/til-api/src/main/java/com/til/common/response/ApiResponse.java
+++ b/til-api/src/main/java/com/til/common/response/ApiResponse.java
@@ -11,7 +11,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class ApiResponse<T> {
 
-    private ApiStatus status;
+    private final ApiStatus status;
 
     @JsonInclude(JsonInclude.Include.NON_NULL)
     private T result;

--- a/til-api/src/main/java/com/til/common/response/ApiStatus.java
+++ b/til-api/src/main/java/com/til/common/response/ApiStatus.java
@@ -8,8 +8,8 @@ import lombok.Getter;
 @Getter
 public class ApiStatus {
 
-    private String code;
-    private String message;
+    private final String code;
+    private final String message;
 
     private ApiStatus(String code, String message) {
         this.code = code;

--- a/til-api/src/main/java/com/til/config/errorhandling/ErrorResponse.java
+++ b/til-api/src/main/java/com/til/config/errorhandling/ErrorResponse.java
@@ -8,7 +8,7 @@ import lombok.Getter;
 @Getter
 public class ErrorResponse {
 
-    private ApiStatus status;
+    private final ApiStatus status;
 
     private ErrorResponse(ErrorCode status) {
         this.status = ApiStatus.of(status);

--- a/til-api/src/main/java/com/til/config/resolver/CurrentUserResolver.java
+++ b/til-api/src/main/java/com/til/config/resolver/CurrentUserResolver.java
@@ -32,7 +32,7 @@ public class CurrentUserResolver implements HandlerMethodArgumentResolver {
 
     @Override
     public Object resolveArgument(@NonNull MethodParameter parameter, ModelAndViewContainer mavContainer,
-        @NonNull NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
+        @NonNull NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
         return Optional.ofNullable(SecurityContextHolder.getContext().getAuthentication())
             .filter(Authentication::isAuthenticated)
             .map(auth -> userService.getUserInfo(auth.getPrincipal().toString()));

--- a/til-domain/src/main/java/com/til/domain/common/enums/BaseErrorCode.java
+++ b/til-domain/src/main/java/com/til/domain/common/enums/BaseErrorCode.java
@@ -2,9 +2,12 @@ package com.til.domain.common.enums;
 
 import org.springframework.http.HttpStatus;
 
+import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 
 @Getter
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 public enum BaseErrorCode implements ErrorCode {
 
     NOT_FOUND(HttpStatus.NOT_FOUND, "해당 데이터를 찾을 수 없습니다."),
@@ -16,9 +19,4 @@ public enum BaseErrorCode implements ErrorCode {
 
     private final HttpStatus status;
     private final String message;
-
-    BaseErrorCode(HttpStatus status, String message) {
-        this.status = status;
-        this.message = message;
-    }
 }

--- a/til-domain/src/main/java/com/til/domain/common/enums/BaseSuccessCode.java
+++ b/til-domain/src/main/java/com/til/domain/common/enums/BaseSuccessCode.java
@@ -1,15 +1,14 @@
 package com.til.domain.common.enums;
 
+import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 
 @Getter
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 public enum BaseSuccessCode implements SuccessCode {
 
     OK("성공하였습니다.");
 
     private final String message;
-
-    BaseSuccessCode(String message) {
-        this.message = message;
-    }
 }

--- a/til-domain/src/main/java/com/til/domain/common/exception/BaseException.java
+++ b/til-domain/src/main/java/com/til/domain/common/exception/BaseException.java
@@ -7,7 +7,7 @@ import lombok.Getter;
 @Getter
 public class BaseException extends RuntimeException {
 
-    private ErrorCode errorCode;
+    private final ErrorCode errorCode;
 
     public BaseException(ErrorCode errorCode) {
         super(errorCode.getMessage());

--- a/til-domain/src/main/java/com/til/domain/user/enums/UserErrorCode.java
+++ b/til-domain/src/main/java/com/til/domain/user/enums/UserErrorCode.java
@@ -4,9 +4,12 @@ import org.springframework.http.HttpStatus;
 
 import com.til.domain.common.enums.ErrorCode;
 
+import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 
 @Getter
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 public enum UserErrorCode implements ErrorCode {
 
     ALREADY_EXISTS_NICKNAME(HttpStatus.BAD_REQUEST, "이미 존재하는 닉네임입니다."),
@@ -16,9 +19,4 @@ public enum UserErrorCode implements ErrorCode {
 
     private final HttpStatus status;
     private final String message;
-
-    UserErrorCode(HttpStatus status, String message) {
-        this.status = status;
-        this.message = message;
-    }
 }

--- a/til-domain/src/main/java/com/til/domain/user/enums/UserSuccessCode.java
+++ b/til-domain/src/main/java/com/til/domain/user/enums/UserSuccessCode.java
@@ -2,9 +2,12 @@ package com.til.domain.user.enums;
 
 import com.til.domain.common.enums.SuccessCode;
 
+import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 
 @Getter
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 public enum UserSuccessCode implements SuccessCode {
 
     SUCCESS_JOIN("회원가입에 성공하였습니다."),
@@ -12,8 +15,4 @@ public enum UserSuccessCode implements SuccessCode {
     POSSIBLE_NICKNAME("사용 가능한 닉네임입니다.");
 
     private final String message;
-
-    UserSuccessCode(String message) {
-        this.message = message;
-    }
 }


### PR DESCRIPTION
## 이슈 번호(링크)

[TIL-70](https://soma-til.atlassian.net/browse/TIL-70)

<br>

## 개요
final modifier를 적용하여 수정 불가능하도록 변경

<br>

## 내용
- final modifier를 적용하여 수정 불가능하도록 변경
- final 관련 필드 생성자 `@Requiredargsconstructor(access = AccessLevel.PRIVATE)`로 대체
- CurrentUserResolver 불필요한 throw 제거

<br>

## 리뷰어한테 할 말
- CurrentUserResolver 불필요한 throw 제거는 branch checkout 하다가 https://github.com/SOMA-TIL/TIL-Backend/pull/22 작업에서 누락되어 이번 작업에 포함시켰습니다


[TIL-70]: https://soma-til.atlassian.net/browse/TIL-70?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ