### PR TITLE
[TIL-90] 기술학습 문제 리스트 구현

### DIFF
--- a/til-api/src/main/java/com/til/controller/problem/ProblemController.java
+++ b/til-api/src/main/java/com/til/controller/problem/ProblemController.java
@@ -1,0 +1,28 @@
+package com.til.controller.problem;
+
+import java.util.List;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.til.application.problem.ProblemService;
+import com.til.common.response.ApiResponse;
+import com.til.controller.problem.reponse.ProblemListResponse;
+import com.til.domain.problem.dto.ProblemInfoDto;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/problem")
+public class ProblemController {
+
+    private final ProblemService problemService;
+
+    @GetMapping("")
+    public ApiResponse<ProblemListResponse> getProblemList() {
+        List<ProblemInfoDto> problemList = problemService.getProblemList();
+        return ApiResponse.ok(ProblemListResponse.of(problemList));
+    }
+}

--- a/til-api/src/main/java/com/til/controller/problem/ProblemController.java
+++ b/til-api/src/main/java/com/til/controller/problem/ProblemController.java
@@ -9,7 +9,7 @@ import org.springframework.web.bind.annotation.RestController;
 import com.til.application.problem.ProblemService;
 import com.til.common.response.ApiResponse;
 import com.til.controller.problem.reponse.ProblemListResponse;
-import com.til.domain.problem.dto.ProblemInfoDto;
+import com.til.domain.problem.dto.ProblemListDto;
 
 import lombok.RequiredArgsConstructor;
 
@@ -22,7 +22,7 @@ public class ProblemController {
 
     @GetMapping("")
     public ApiResponse<ProblemListResponse> getProblemList() {
-        List<ProblemInfoDto> problemList = problemService.getProblemList();
+        List<ProblemListDto> problemList = problemService.getProblemList();
         return ApiResponse.ok(ProblemListResponse.of(problemList));
     }
 }

--- a/til-api/src/main/java/com/til/controller/problem/reponse/ProblemListResponse.java
+++ b/til-api/src/main/java/com/til/controller/problem/reponse/ProblemListResponse.java
@@ -2,13 +2,13 @@ package com.til.controller.problem.reponse;
 
 import java.util.List;
 
-import com.til.domain.problem.dto.ProblemInfoDto;
+import com.til.domain.problem.dto.ProblemListDto;
 
 public record ProblemListResponse(
-                                  List<ProblemInfoDto> problemInfoDtoList
+                                  List<ProblemListDto> problemList
 ) {
 
-    public static ProblemListResponse of(List<ProblemInfoDto> problemInfoDtoList) {
-        return new ProblemListResponse(problemInfoDtoList);
+    public static ProblemListResponse of(List<ProblemListDto> problemList) {
+        return new ProblemListResponse(problemList);
     }
 }

--- a/til-api/src/main/java/com/til/controller/problem/reponse/ProblemListResponse.java
+++ b/til-api/src/main/java/com/til/controller/problem/reponse/ProblemListResponse.java
@@ -1,0 +1,14 @@
+package com.til.controller.problem.reponse;
+
+import java.util.List;
+
+import com.til.domain.problem.dto.ProblemInfoDto;
+
+public record ProblemListResponse(
+                                  List<ProblemInfoDto> problemInfoDtoList
+) {
+
+    public static ProblemListResponse of(List<ProblemInfoDto> problemInfoDtoList) {
+        return new ProblemListResponse(problemInfoDtoList);
+    }
+}

--- a/til-domain/src/main/java/com/til/application/problem/ProblemService.java
+++ b/til-domain/src/main/java/com/til/application/problem/ProblemService.java
@@ -6,7 +6,7 @@ import java.util.stream.Collectors;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.til.domain.problem.dto.ProblemInfoDto;
+import com.til.domain.problem.dto.ProblemListDto;
 import com.til.domain.problem.model.Problem;
 import com.til.domain.problem.repository.ProblemRepository;
 
@@ -14,15 +14,15 @@ import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class ProblemService {
 
     private final ProblemRepository problemRepository;
 
-    @Transactional(readOnly = true)
-    public List<ProblemInfoDto> getProblemList() {
+    public List<ProblemListDto> getProblemList() {
         List<Problem> problemList = problemRepository.findAll();
         return problemList.stream()
-            .map(ProblemInfoDto::of)
+            .map(ProblemListDto::of)
             .collect(Collectors.toList());
     }
 

--- a/til-domain/src/main/java/com/til/application/problem/ProblemService.java
+++ b/til-domain/src/main/java/com/til/application/problem/ProblemService.java
@@ -1,0 +1,29 @@
+package com.til.application.problem;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.til.domain.problem.dto.ProblemInfoDto;
+import com.til.domain.problem.model.Problem;
+import com.til.domain.problem.repository.ProblemRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class ProblemService {
+
+    private final ProblemRepository problemRepository;
+
+    @Transactional(readOnly = true)
+    public List<ProblemInfoDto> getProblemList() {
+        List<Problem> problemList = problemRepository.findAll();
+        return problemList.stream()
+            .map(ProblemInfoDto::of)
+            .collect(Collectors.toList());
+    }
+
+}

--- a/til-domain/src/main/java/com/til/domain/problem/dto/ProblemDto.java
+++ b/til-domain/src/main/java/com/til/domain/problem/dto/ProblemDto.java
@@ -5,15 +5,15 @@ import com.til.domain.problem.model.Problem;
 import lombok.Builder;
 
 @Builder
-public record ProblemInfoDto(
-                             String title,
-                             String question,
-                             String solution,
-                             Integer score
+public record ProblemDto(
+                         String title,
+                         String question,
+                         String solution,
+                         Integer score
 ) {
 
-    public static ProblemInfoDto of(Problem problem) {
-        return ProblemInfoDto.builder()
+    public static ProblemDto of(Problem problem) {
+        return ProblemDto.builder()
             .title(problem.getTitle())
             .question(problem.getQuestion())
             .solution(problem.getSolution())

--- a/til-domain/src/main/java/com/til/domain/problem/dto/ProblemInfoDto.java
+++ b/til-domain/src/main/java/com/til/domain/problem/dto/ProblemInfoDto.java
@@ -1,0 +1,23 @@
+package com.til.domain.problem.dto;
+
+import com.til.domain.problem.model.Problem;
+
+import lombok.Builder;
+
+@Builder
+public record ProblemInfoDto(
+                             String title,
+                             String question,
+                             String solution,
+                             Integer score
+) {
+
+    public static ProblemInfoDto of(Problem problem) {
+        return ProblemInfoDto.builder()
+            .title(problem.getTitle())
+            .question(problem.getQuestion())
+            .solution(problem.getSolution())
+            .score(problem.getScore())
+            .build();
+    }
+}

--- a/til-domain/src/main/java/com/til/domain/problem/dto/ProblemListDto.java
+++ b/til-domain/src/main/java/com/til/domain/problem/dto/ProblemListDto.java
@@ -1,0 +1,19 @@
+package com.til.domain.problem.dto;
+
+import com.til.domain.problem.model.Problem;
+
+import lombok.Builder;
+
+@Builder
+public record ProblemListDto(
+                             String title,
+                             Integer score
+) {
+
+    public static ProblemListDto of(Problem problem) {
+        return ProblemListDto.builder()
+            .title(problem.getTitle())
+            .score(problem.getScore())
+            .build();
+    }
+}

--- a/til-domain/src/main/java/com/til/domain/problem/model/Problem.java
+++ b/til-domain/src/main/java/com/til/domain/problem/model/Problem.java
@@ -1,0 +1,38 @@
+package com.til.domain.problem.model;
+
+import com.til.domain.common.model.BaseTimeEntity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+@Entity
+@Getter
+@SuperBuilder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "problem")
+public class Problem extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String title;
+
+    @Column(nullable = false)
+    private String question;
+
+    @Column(nullable = false)
+    private String solution;
+
+    @Column(nullable = true)
+    private Integer score;
+}

--- a/til-domain/src/main/java/com/til/domain/problem/repository/ProblemRepository.java
+++ b/til-domain/src/main/java/com/til/domain/problem/repository/ProblemRepository.java
@@ -1,0 +1,8 @@
+package com.til.domain.problem.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.til.domain.problem.model.Problem;
+
+public interface ProblemRepository extends JpaRepository<Problem, Long> {
+}


### PR DESCRIPTION
## 이슈 번호(링크)

[TIL-90](https://soma-til.atlassian.net/browse/TIL-90)

<br>

## 개요

- 기술학습 문제(Problem) 리스트 구현

<br>

## 내용

- Problem Entity, Repository 생성
- ProblemService, ProblemInfoDto 생성
- ProblemController, ProblemListResponse 생성

- Postman Response 결과 (테스트는 PathPermission에 "problem/**" 을 넣고 테스트함. )
<img width="1277" alt="image" src="https://github.com/user-attachments/assets/1109b04e-95b6-4c8e-a3fc-fede72c262ad">

<br>

## 리뷰어한테 할 말

- 페이징 객체가 jpa에 dependency가 있어, api 모듈에서 사용하지 않게 구현해볼 예정입니다. 리스트에서 페이징 기능 추가하고, 테스트 코드 작성할 예정입니다.
- 추가적인 Errorcode나 SuccessCode 작성이 필요하다면 말씀해주세요. 
- Dto나 Response 사용 부분에 수정할 부분이나 개선할 점이 있다면 알려주세요! 


[TIL-90]: https://soma-til.atlassian.net/browse/TIL-90?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ