### PR TITLE
[TIL-96] JWT 토큰 인증 실패시 반환하는 response status 리소스명으로 묶기

### DIFF
--- a/til-api/src/main/java/com/til/config/security/AuthenticationFilter.java
+++ b/til-api/src/main/java/com/til/config/security/AuthenticationFilter.java
@@ -60,14 +60,7 @@ public class AuthenticationFilter extends OncePerRequestFilter {
         }
 
         String token = resolveToken(request);
-        if (token == null) {
-            handleException(response);
-            return;
-        }
-
-        try {
-            tokenProvider.validateToken(token);
-        } catch (Exception e) {
+        if (token == null || !validateToken(token)) {
             handleException(response);
             return;
         }
@@ -75,6 +68,15 @@ public class AuthenticationFilter extends OncePerRequestFilter {
         Authentication auth = createAuthentication(tokenProvider.parseClaims(token));
         SecurityContextHolder.getContext().setAuthentication(auth);
         filterChain.doFilter(request, response);
+    }
+
+    private boolean validateToken(String token) {
+        try {
+            tokenProvider.validateToken(token);
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
     }
 
     private String resolveToken(HttpServletRequest request) {

--- a/til-api/src/main/java/com/til/config/security/AuthenticationFilter.java
+++ b/til-api/src/main/java/com/til/config/security/AuthenticationFilter.java
@@ -16,7 +16,7 @@ import org.springframework.util.AntPathMatcher;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.til.common.response.ApiStatus;
+import com.til.config.errorhandling.ErrorResponse;
 import com.til.domain.auth.provider.TokenProvider;
 import com.til.domain.common.enums.BaseErrorCode;
 import com.til.domain.user.model.Role;
@@ -99,6 +99,6 @@ public class AuthenticationFilter extends OncePerRequestFilter {
     private void handleException(HttpServletResponse response) throws IOException {
         response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
         response.setContentType("application/json; charset=UTF-8");
-        response.getWriter().write(objectMapper.writeValueAsString(ApiStatus.of(BaseErrorCode.UNAUTHORIZED)));
+        response.getWriter().write(objectMapper.writeValueAsString(ErrorResponse.of(BaseErrorCode.UNAUTHORIZED)));
     }
 }


### PR DESCRIPTION
## 이슈 번호(링크)
[TIL-96](https://soma-til.atlassian.net/browse/TIL-96)

<br>

## 개요
JWT 토큰 인증 실패시 반환하는 response status 리소스명으로 묶기
<br>

## 내용
- JWT 토큰 인증 실패시 반환하는 response status 리소스명으로 묶음
   ```json
   {
        "status": {
            "code": "UNAUTHORIZED",
            "message": "인증되지 않은 사용자입니다."
        }
    }
   ```
- 토큰 검증 if 하나에서 진행할 수 있도록 validateToken 생성

<br>

## 리뷰어한테 할 말
😀


[TIL-96]: https://soma-til.atlassian.net/browse/TIL-96?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ