### PR TITLE
[TIL-103] JWT 토큰 검증 필터 on/off 기능 구현

### DIFF
--- a/til-api/src/main/java/com/til/config/AppConfig.java
+++ b/til-api/src/main/java/com/til/config/AppConfig.java
@@ -1,0 +1,15 @@
+package com.til.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import lombok.Getter;
+
+@Component
+public class AppConfig {
+
+    @Getter
+    @Value("${jwt.filter.enabled:true}")
+    private boolean jwtFilterEnabled;
+
+}

--- a/til-api/src/main/java/com/til/config/resolver/CurrentUserResolver.java
+++ b/til-api/src/main/java/com/til/config/resolver/CurrentUserResolver.java
@@ -13,15 +13,19 @@ import org.springframework.web.method.support.ModelAndViewContainer;
 
 import com.til.application.user.UserService;
 import com.til.common.annotation.CurrentUser;
+import com.til.config.AppConfig;
 import com.til.domain.user.dto.UserInfoDto;
 
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 @Component
 @RequiredArgsConstructor
+@Slf4j
 public class CurrentUserResolver implements HandlerMethodArgumentResolver {
 
+    private final AppConfig appConfig;
     private final UserService userService;
 
     @Override
@@ -33,6 +37,9 @@ public class CurrentUserResolver implements HandlerMethodArgumentResolver {
     @Override
     public Object resolveArgument(@NonNull MethodParameter parameter, ModelAndViewContainer mavContainer,
         @NonNull NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
+        if (!appConfig.isJwtFilterEnabled()) { // for test
+            return userService.getUserInfo("til@gmail.com");
+        }
         return Optional.ofNullable(SecurityContextHolder.getContext().getAuthentication())
             .filter(Authentication::isAuthenticated)
             .map(auth -> userService.getUserInfo(auth.getPrincipal().toString()));

--- a/til-api/src/main/java/com/til/config/security/AuthenticationFilter.java
+++ b/til-api/src/main/java/com/til/config/security/AuthenticationFilter.java
@@ -16,6 +16,7 @@ import org.springframework.util.AntPathMatcher;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.til.config.AppConfig;
 import com.til.config.errorhandling.ErrorResponse;
 import com.til.domain.auth.provider.TokenProvider;
 import com.til.domain.common.enums.BaseErrorCode;
@@ -35,18 +36,18 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class AuthenticationFilter extends OncePerRequestFilter {
 
+    private static final String AUTHORIZATION_HEADER = "Authorization";
+    private static final String BEARER_TYPE = "Bearer";
+
+    private final AppConfig appConfig;
     private final TokenProvider tokenProvider;
     private final AntPathMatcher pathMatcher = new AntPathMatcher();
     private final ObjectMapper objectMapper = new ObjectMapper();
 
-    private static final String AUTHORIZATION_HEADER = "Authorization";
-    private static final String BEARER_TYPE = "Bearer";
-
     @Override
     protected boolean shouldNotFilter(HttpServletRequest request) {
-        String path = request.getRequestURI();
-        return Stream.of(PathPermission.getPublicPath())
-            .anyMatch(pattern -> pathMatcher.match(pattern, path));
+        return !appConfig.isJwtFilterEnabled() || Stream.of(PathPermission.getPublicPath())
+            .anyMatch(pattern -> pathMatcher.match(pattern, request.getRequestURI()));
     }
 
     @Override

--- a/til-api/src/main/java/com/til/config/security/SecurityConfig.java
+++ b/til-api/src/main/java/com/til/config/security/SecurityConfig.java
@@ -1,44 +1,58 @@
 package com.til.config.security;
 
-import static org.springframework.security.config.http.SessionCreationPolicy.*;
+import static org.springframework.security.config.http.SessionCreationPolicy.STATELESS;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.annotation.web.configurers.AuthorizeHttpRequestsConfigurer;
 import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
+import com.til.config.AppConfig;
 import com.til.domain.user.model.Role;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 @Configuration
 @EnableWebSecurity
 @RequiredArgsConstructor
+@Slf4j
 public class SecurityConfig {
 
+    private final AppConfig appConfig;
     private final AuthenticationFilter authenticationFilter;
     private final AuthenticationDeniedHandler authenticationDeniedHandler;
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        log.info("JWT Filter Enabled: {}", appConfig.isJwtFilterEnabled());
+
         http
             .formLogin(AbstractHttpConfigurer::disable)
             .httpBasic(AbstractHttpConfigurer::disable)
             .csrf(AbstractHttpConfigurer::disable)
             .headers((headers) -> headers.frameOptions(HeadersConfigurer.FrameOptionsConfig::disable))
             .sessionManagement(session -> session.sessionCreationPolicy(STATELESS))
-            .authorizeHttpRequests((request) -> request
-                .requestMatchers(PathPermission.getPublicPath()).permitAll()
-                .requestMatchers(PathPermission.getAdminPath()).hasRole(Role.ADMIN.name())
-                .anyRequest().authenticated()
-            )
+            .authorizeHttpRequests(this::getAuthenticated)
             .exceptionHandling((except) -> except.accessDeniedHandler(authenticationDeniedHandler))
             .addFilterBefore(authenticationFilter, UsernamePasswordAuthenticationFilter.class);
 
         return http.build();
+    }
+
+    private void getAuthenticated(
+        AuthorizeHttpRequestsConfigurer<HttpSecurity>.AuthorizationManagerRequestMatcherRegistry request) {
+        if (!appConfig.isJwtFilterEnabled()) {
+            request.anyRequest().permitAll();
+            return;
+        }
+        request.requestMatchers(PathPermission.getPublicPath()).permitAll()
+            .requestMatchers(PathPermission.getAdminPath()).hasRole(Role.ADMIN.name())
+            .anyRequest().authenticated();
     }
 }


### PR DESCRIPTION
## 이슈 번호(링크)

[TIL-103](https://soma-til.atlassian.net/browse/TIL-103)

<br>

## 개요
개발 편의성을 위해 JWT 토큰 검증 필터를 환경변수 값을 통해 on/off 할 수 있도록 함

<br>

## 내용
- 환경 변수 파일 정의한 jwt.filter.enabled 값을 통해 토큰 검증 필터 사용이 제어됨
  ```yaml
  ...
  jwt:
    filter:
      enabled: true # JWT 필터 사용 여부 설정 (true: 사용, false: 미사용 => 기본 값은 true)
  ...
  ```
  - 토큰 검증 필터가 비활성화 될 경우 `@CurrentUser`로 불러오는 유저 정보
    - 더미 데이터로 넣어준 사용자인 `til@gmail.com`로 사용자를 데려오는 것으로 설정
- 환경 변수 파일 `application-custom.yml` 사용할 수 있도록 설정
  - 목적 : 팀원 개발 상황에 맞게 환경 변수 세팅할 수 있도록 application-custom.yml 사용하고자 함
  - .gitignore로 commit 대상에서 제외시키고 application.yml에서는 파일 import 시킴


<br>

## 리뷰어한테 할 말
- 환경 변수 조건에 따라 SecurityConfig 클래스에서 토큰 검증 필터가 비활성화되어야 하는 경우 AuthenticationFilter가 등록되지 않도록 if를 활용해 적용했었는데 AuthenticationFilter가 여전히 실행되는 문제가 발생하였습니다.
- 문제를 해결하기 위해 우선은 AuthenticationFilter 안에 shouldNotFilter에서도 조건문을 통해 비활성 처리를 추가하였습니다.
- `application-custom.yml` 사용 예시
   저의 경우 프로필 이름을 custom으로 두고 필요한 설정(jwt 필터 조건, 토큰 만료 시간 등)을 변경하여 테스트 진행중입니다!
   <img src="https://github.com/user-attachments/assets/ff58d0d1-1088-453e-b986-693a9043cafd" width=500 />



[TIL-103]: https://soma-til.atlassian.net/browse/TIL-103?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ