### PR TITLE
[TIL-85] UserInfoValidator 테스트 코드 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -76,8 +76,10 @@ subprojects {
         testImplementation 'org.springframework.security:spring-security-test'
         testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
+        testImplementation 'org.junit.jupiter:junit-jupiter:5.8.1'
         testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.1'
-        testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.8.1'
+        testImplementation 'org.junit.jupiter:junit-jupiter-params:5.8.1'
+        testImplementation 'org.junit.jupiter:junit-jupiter-engine:5.8.1'
     }
 
     test {

--- a/til-domain/src/test/java/com/til/domain/user/validator/UserInfoValidatorTest.java
+++ b/til-domain/src/test/java/com/til/domain/user/validator/UserInfoValidatorTest.java
@@ -1,0 +1,82 @@
+package com.til.domain.user.validator;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+import java.util.stream.Stream;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import com.til.domain.common.exception.InvalidDtoException;
+
+class UserInfoValidatorTest {
+
+    private final UserInfoValidator userInfoValidator = new UserInfoValidator();
+
+    private static Stream<Arguments> validNicknameProvider() {
+        return Stream.of(
+            Arguments.of("닉네임 정보가 2자인 경우", "ab"),
+            Arguments.of("닉네임 정보가 12자인 경우", "123456789012"),
+            Arguments.of("닉네임 정보가 한글로만 구성되어 있는 경우", "한글닉네임"),
+            Arguments.of("닉네임 정보가 영문으로만 구성되어 있는 경우", "Nickname"),
+            Arguments.of("닉네임 정보가 숫자로만 구성되어 있는 경우", "1234"),
+            Arguments.of("닉네임 정보가 한글, 영문, 숫자로 구성되어 있는 경우", "한글en12")
+        );
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("validNicknameProvider")
+    void 회원가입_정보에서_닉네임_정보가_유효하면_예외를_던지지_않는다(String description, String nickname) {
+        assertDoesNotThrow(() -> userInfoValidator.validateJoinInfo(nickname, "password1234"));
+    }
+
+    private static Stream<Arguments> invalidNicknameProvider() {
+        return Stream.of(
+            Arguments.of("닉네임 정보가 1자 이하인 경우", "a", InvalidDtoException.class),
+            Arguments.of("닉네임 정보가 13자 이상인 경우", "12345678901234", InvalidDtoException.class),
+            Arguments.of("닉네임 정보가 특수문자를 포함한 경우", "nickname!", InvalidDtoException.class)
+        );
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("invalidNicknameProvider")
+    void 회원가입_정보에서_닉네임_정보가_유효하지_않으면_예외를_던진다(String description, String nickname,
+        Class<? extends Exception> expectedException) {
+        assertThatThrownBy(() -> userInfoValidator.validateJoinInfo(nickname, "password1234"))
+            .isInstanceOf(expectedException);
+    }
+
+    private static Stream<Arguments> validPasswordProvider() {
+        return Stream.of(
+            Arguments.of("비밀번호 정보가 영문, 숫자 조합으로 8자 이상 20자 이하인 경우", "Password1234"),
+            Arguments.of("비밀번호 정보가 8자인 경우", "Password1"),
+            Arguments.of("비밀번호 정보가 20자인 경우", "Password123456789012")
+        );
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("validPasswordProvider")
+    void 회원가입_정보에서_비밀번호_정보가_유효하면_예외를_던지지_않는다(String description, String password) {
+        assertDoesNotThrow(() -> userInfoValidator.validateJoinInfo("nickname", password));
+    }
+
+    private static Stream<Arguments> invalidPasswordProvider() {
+        return Stream.of(
+            Arguments.of("비밀번호 정보가 7자인 경우", "Passwo1", InvalidDtoException.class),
+            Arguments.of("비밀번호 정보가 21자인 경우", "Password1234567890123", InvalidDtoException.class),
+            Arguments.of("비밀번호 정보가 영문만 포함된 경우", "Password", InvalidDtoException.class),
+            Arguments.of("비밀번호 정보가 숫자만 포함된 경우", "12345678", InvalidDtoException.class),
+            Arguments.of("비밀번호 정보가 특수문자를 포함한 경우", "Password!", InvalidDtoException.class)
+        );
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("invalidPasswordProvider")
+    void 회원가입_정보에서_비밀번호_정보가_유효하지_않으면_예외를_던진다(String description, String password,
+        Class<? extends Exception> expectedException) {
+        assertThatThrownBy(() -> userInfoValidator.validateJoinInfo("nickname", password))
+            .isInstanceOf(expectedException);
+    }
+}


### PR DESCRIPTION
## 이슈 번호(링크)

[TIL-85](https://soma-til.atlassian.net/browse/TIL-85)

<br>

## 개요
UserInfoValidator 테스트 코드 추가

<br>

## 내용
- UserInfoValidator 테스트 코드 추가
   <img width="543" alt="image" src="https://github.com/user-attachments/assets/7fa96ebd-1ed4-4c40-ad5e-86aedf1beccf">


<br>

## 리뷰어한테 할 말
- `@ParameterizedTest`를 사용해서 중복되는 테스트 코드를 줄이고자 했습니다.

[TIL-85]: https://soma-til.atlassian.net/browse/TIL-85?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ