### PR TITLE
[TIL-108] logging 설정 파일 내부에 정의된 springProfile 제거

### DIFF
--- a/log4j2/log4j2-dev.yml
+++ b/log4j2/log4j2-dev.yml
@@ -1,54 +1,51 @@
 configuration:
   name: til-dev
 
-  springProfile:
-    name: dev
+  properties:
+    property:
+      - name: "log-path"
+        value: "./log4j2/logs"
+      - name: "charset-UTF-8"
+        value: "UTF-8"
+      - name: "file-pattern"
+        value: "%d %p [%t] %C{1.}: %m%n"
+      - name: "console-pattern"
+        value: "%black{%d} %clr{%-5level} %magenta{[%t]} %cyan{%C}: %msg%n%throwable"
 
-    properties:
-      property:
-        - name: "log-path"
-          value: "./log4j2/logs"
-        - name: "charset-UTF-8"
-          value: "UTF-8"
-        - name: "file-pattern"
-          value: "%d %p [%t] %C{1.}: %m%n"
-        - name: "console-pattern"
-          value: "%black{%d} %clr{%-5level} %magenta{[%t]} %cyan{%C}: %msg%n%throwable"
+  appenders:
+    console:
+      - name: console-appender
+        target: SYSTEM_OUT
+        patternLayout:
+          pattern: ${console-pattern}
 
-    appenders:
-      console:
-        - name: console-appender
-          target: SYSTEM_OUT
-          patternLayout:
-            pattern: ${console-pattern}
+    rollingFile:
+      - name: rolling-file-appender
+        fileName: ${log-path}/dev.log
+        filePattern: "${log-path}/archive/dev_%d{yyyy-MM-dd}_%i.log.gz"
+        patternLayout:
+          charset: ${charset-UTF-8}
+          pattern: ${file-pattern}
+        policies:
+          SizeBasedTriggeringPolicy:
+            size: "100MB"
+          TimeBasedTriggeringPolicy:
+            interval: "1"
+        DefaultRollOverStrategy:
+          max: "30"
+          fileIndex: "max"
 
-      rollingFile:
-        - name: rolling-file-appender
-          fileName: ${log-path}/dev.log
-          filePattern: "${log-path}/archive/dev_%d{yyyy-MM-dd}_%i.log.gz"
-          patternLayout:
-            charset: ${charset-UTF-8}
-            pattern: ${file-pattern}
-          policies:
-            SizeBasedTriggeringPolicy:
-              size: "100MB"
-            TimeBasedTriggeringPolicy:
-              interval: "1"
-          DefaultRollOverStrategy:
-            max: "30"
-            fileIndex: "max"
+  loggers:
+    root:
+      level: INFO
+      appenderRef:
+        - ref: console-appender
+        - ref: rolling-file-appender
 
-    loggers:
-      root:
-        level: INFO
+    logger:
+      - name: com.til
+        additivity: "false"
+        level: DEBUG
         appenderRef:
           - ref: console-appender
           - ref: rolling-file-appender
-
-      logger:
-        - name: com.til
-          additivity: "false"
-          level: DEBUG
-          appenderRef:
-            - ref: console-appender
-            - ref: rolling-file-appender

--- a/log4j2/log4j2-local.yml
+++ b/log4j2/log4j2-local.yml
@@ -1,30 +1,27 @@
 configuration:
   name: til-local
 
-  springProfile:
-    name: local
+  properties:
+    property:
+      - name: "console-pattern"
+        value: "%black{%d} %clr{%-5level} %magenta{[%t]} %cyan{%C}: %msg%n%throwable"
 
-    properties:
-      property:
-        - name: "console-pattern"
-          value: "%black{%d} %clr{%-5level} %magenta{[%t]} %cyan{%C}: %msg%n%throwable"
+  appenders:
+    console:
+      - name: console-appender
+        target: SYSTEM_OUT
+        patternLayout:
+          pattern: ${console-pattern}
 
-    appenders:
-      console:
-        - name: console-appender
-          target: SYSTEM_OUT
-          patternLayout:
-            pattern: ${console-pattern}
+  loggers:
+    root:
+      level: INFO
+      appenderRef:
+        - ref: console-appender
 
-    loggers:
-      root:
-        level: INFO
+    logger:
+      - name: com.til
+        additivity: "false"
+        level: DEBUG
         appenderRef:
           - ref: console-appender
-
-      logger:
-        - name: com.til
-          additivity: "false"
-          level: DEBUG
-          appenderRef:
-            - ref: console-appender

--- a/log4j2/log4j2-prod.yml
+++ b/log4j2/log4j2-prod.yml
@@ -1,38 +1,35 @@
 configuration:
   name: til-prod
 
-  springProfile:
-    name: prod
+  properties:
+    property:
+      - name: "log-path"
+        value: "./log4j2/logs"
+      - name: "charset-UTF-8"
+        value: "UTF-8"
+      - name: "file-pattern"
+        value: "%d %p [%t] %C{1.}: %m%n"
 
-    properties:
-      property:
-        - name: "log-path"
-          value: "./log4j2/logs"
-        - name: "charset-UTF-8"
-          value: "UTF-8"
-        - name: "file-pattern"
-          value: "%d %p [%t] %C{1.}: %m%n"
+  appenders:
+    rollingFile:
+      - name: rolling-file-appender
+        fileName: ${log-path}/prod.log
+        filePattern: "${log-path}/archive/prod_%d{yyyy-MM-dd}_%i.log.gz"
+        patternLayout:
+          charset: ${charset-UTF-8}
+          pattern: ${file-pattern}
+        policies:
+          SizeBasedTriggeringPolicy:
+            size: "100MB"
+          TimeBasedTriggeringPolicy:
+            interval: "1"
+        DefaultRollOverStrategy:
+          max: "30"
+          fileIndex: "max"
 
-    appenders:
-      rollingFile:
-        - name: rolling-file-appender
-          fileName: ${log-path}/prod.log
-          filePattern: "${log-path}/archive/prod_%d{yyyy-MM-dd}_%i.log.gz"
-          patternLayout:
-            charset: ${charset-UTF-8}
-            pattern: ${file-pattern}
-          policies:
-            SizeBasedTriggeringPolicy:
-              size: "100MB"
-            TimeBasedTriggeringPolicy:
-              interval: "1"
-          DefaultRollOverStrategy:
-            max: "30"
-            fileIndex: "max"
-
-    loggers:
-      root:
-        level: ERROR
-        appenderRef:
-          - ref: console-appender
-          - ref: rolling-file-appender
+  loggers:
+    root:
+      level: ERROR
+      appenderRef:
+        - ref: console-appender
+        - ref: rolling-file-appender

--- a/log4j2/log4j2-test.yml
+++ b/log4j2/log4j2-test.yml
@@ -1,30 +1,27 @@
 configuration:
   name: til-test
 
-  springProfile:
-    name: test
+  properties:
+    property:
+      - name: "console-pattern"
+        value: "%black{%d} %clr{%-5level} %magenta{[%t]} %cyan{%C}: %msg%n%throwable"
 
-    properties:
-      property:
-        - name: "console-pattern"
-          value: "%black{%d} %clr{%-5level} %magenta{[%t]} %cyan{%C}: %msg%n%throwable"
+  appenders:
+    console:
+      - name: console-appender
+        target: SYSTEM_OUT
+        patternLayout:
+          pattern: ${console-pattern}
 
-    appenders:
-      console:
-        - name: console-appender
-          target: SYSTEM_OUT
-          patternLayout:
-            pattern: ${console-pattern}
+  loggers:
+    root:
+      level: INFO
+      appenderRef:
+        - ref: console-appender
 
-    loggers:
-      root:
-        level: INFO
+    logger:
+      - name: com.til
+        additivity: "false"
+        level: DEBUG
         appenderRef:
           - ref: console-appender
-
-      logger:
-        - name: com.til
-          additivity: "false"
-          level: DEBUG
-          appenderRef:
-            - ref: console-appender


### PR DESCRIPTION
## 이슈 번호(링크)

[TIL-108](https://soma-til.atlassian.net/browse/TIL-108)

<br>

## 개요
logging 설정 파일 내부에 정의된 springProfile 제거
- 제거 이유
  - application-환경.yml 파일 안에서 필요한 로깅 파일을 import 하는 구조로 되어 있음
  - 로깅 파일 내부에 프로필이 명시되어 있지 않아도 환경별로 분리한 로깅 설정 파일을 import하면 원하는 방식으로 로깅 설정 가능

<br>

## 내용
- logging 파일 속 springProfile 제거 완료

<br>

## 리뷰어한테 할 말
😀


[TIL-108]: https://soma-til.atlassian.net/browse/TIL-108?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ