### PR TITLE
[TIL-112] 로그아웃 API 구현

### DIFF
--- a/til-api/src/main/java/com/til/config/resolver/CurrentUserResolver.java
+++ b/til-api/src/main/java/com/til/config/resolver/CurrentUserResolver.java
@@ -14,6 +14,8 @@ import org.springframework.web.method.support.ModelAndViewContainer;
 import com.til.application.user.UserService;
 import com.til.common.annotation.CurrentUser;
 import com.til.config.AppConfig;
+import com.til.domain.common.enums.BaseErrorCode;
+import com.til.domain.common.exception.BaseException;
 import com.til.domain.user.dto.UserInfoDto;
 
 import lombok.NonNull;
@@ -35,13 +37,15 @@ public class CurrentUserResolver implements HandlerMethodArgumentResolver {
     }
 
     @Override
-    public Object resolveArgument(@NonNull MethodParameter parameter, ModelAndViewContainer mavContainer,
+    public UserInfoDto resolveArgument(@NonNull MethodParameter parameter, ModelAndViewContainer mavContainer,
         @NonNull NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
         if (!appConfig.isJwtFilterEnabled()) { // for test
             return userService.getUserInfo("til@gmail.com");
         }
-        return Optional.ofNullable(SecurityContextHolder.getContext().getAuthentication())
+
+        return Optional.of(SecurityContextHolder.getContext().getAuthentication())
             .filter(Authentication::isAuthenticated)
-            .map(auth -> userService.getUserInfo(auth.getPrincipal().toString()));
+            .map(auth -> userService.getUserInfo(auth.getPrincipal().toString()))
+            .orElseThrow(() -> new BaseException(BaseErrorCode.UNAUTHORIZED));
     }
 }

--- a/til-api/src/main/java/com/til/config/security/PathPermission.java
+++ b/til-api/src/main/java/com/til/config/security/PathPermission.java
@@ -3,7 +3,7 @@ package com.til.config.security;
 public class PathPermission {
 
     public static String[] getPublicPath() {
-        return new String[]{"/user/**"};
+        return new String[]{"/user/join", "/user/login", "/user/nickname/**"};
     }
 
     public static String[] getAdminPath() {

--- a/til-api/src/main/java/com/til/controller/user/UserController.java
+++ b/til-api/src/main/java/com/til/controller/user/UserController.java
@@ -9,12 +9,14 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.til.application.auth.AuthService;
 import com.til.application.user.UserService;
+import com.til.common.annotation.CurrentUser;
 import com.til.common.response.ApiResponse;
 import com.til.controller.user.request.UserJoinRequest;
 import com.til.controller.user.request.UserLoginRequest;
 import com.til.controller.user.response.UserLoginResponse;
 import com.til.domain.auth.dto.AuthTokenDto;
 import com.til.domain.auth.dto.AuthUserInfoDto;
+import com.til.domain.user.dto.UserInfoDto;
 import com.til.domain.user.enums.UserSuccessCode;
 
 import jakarta.validation.Valid;
@@ -40,6 +42,12 @@ public class UserController {
         AuthTokenDto token = authService.createToken(userInfoDto);
 
         return ApiResponse.ok(UserSuccessCode.SUCCESS_LOGIN, UserLoginResponse.of(userInfoDto, token));
+    }
+
+    @GetMapping("/logout")
+    public ApiResponse<Void> logout(@CurrentUser UserInfoDto userInfo) {
+        authService.deleteToken(userInfo.email());
+        return ApiResponse.ok(UserSuccessCode.SUCCESS_LOGOUT);
     }
 
     @GetMapping("/nickname/{nickname}")

--- a/til-domain/src/main/java/com/til/domain/user/enums/UserSuccessCode.java
+++ b/til-domain/src/main/java/com/til/domain/user/enums/UserSuccessCode.java
@@ -12,7 +12,8 @@ public enum UserSuccessCode implements SuccessCode {
 
     SUCCESS_JOIN("회원가입에 성공하였습니다."),
     SUCCESS_LOGIN("로그인에 성공하였습니다."),
-    POSSIBLE_NICKNAME("사용 가능한 닉네임입니다.");
+    POSSIBLE_NICKNAME("사용 가능한 닉네임입니다."),
+    SUCCESS_LOGOUT("로그아웃에 성공하였습니다.");
 
     private final String message;
 }


### PR DESCRIPTION
## 이슈 번호(링크)

[TIL-112](https://soma-til.atlassian.net/browse/TIL-112)

<br>

## 개요
로그아웃 API 구현

<br>

## 내용
- 로그아웃 요청시 redis 캐시에 저장한 refresh 토큰 정보 삭제
- 참고 : [로그아웃 API 문서](https://soma-til.notion.site/cfd53c24ca24434f9042e709674b9f07)
<br>

## 리뷰어한테 할 말
😀

[TIL-112]: https://soma-til.atlassian.net/browse/TIL-112?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ