### PR TITLE
[TIL-100] 기술학습 문제 상세 정보 조회 구현

### DIFF
--- a/til-api/src/main/java/com/til/controller/problem/ProblemController.java
+++ b/til-api/src/main/java/com/til/controller/problem/ProblemController.java
@@ -2,6 +2,7 @@ package com.til.controller.problem;
 
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -9,8 +10,10 @@ import com.til.application.problem.ProblemService;
 import com.til.common.Page.PageParamRequest;
 import com.til.common.Page.PageResponse;
 import com.til.common.response.ApiResponse;
+import com.til.controller.problem.Response.ProblemInfoResponse;
 import com.til.domain.common.enums.BaseErrorCode;
 import com.til.domain.common.exception.BaseException;
+import com.til.domain.problem.dto.ProblemInfoDto;
 import com.til.domain.problem.dto.ProblemListDto;
 import com.til.domain.problem.dto.ProblemListInfoDto;
 import com.til.domain.problem.enums.ProblemSuccessCode;
@@ -34,4 +37,11 @@ public class ProblemController {
         return ApiResponse.ok(ProblemSuccessCode.SUCCESS_GET_PROBLEMS, PageResponse.of(problemListDto.problems(),
             problemListDto.pageInfo()));
     }
+
+    @GetMapping("/{id}")
+    public ApiResponse<ProblemInfoResponse> getProblemInfo(@PathVariable Long id) {
+        ProblemInfoDto problemInfoDto = problemService.getProblemInfo(id);
+        return ApiResponse.ok(ProblemSuccessCode.SUCCESS_GET_PROBLEM_INFO, ProblemInfoResponse.of(problemInfoDto));
+    }
+
 }

--- a/til-api/src/main/java/com/til/controller/problem/ProblemController.java
+++ b/til-api/src/main/java/com/til/controller/problem/ProblemController.java
@@ -34,7 +34,7 @@ public class ProblemController {
             throw new BaseException(BaseErrorCode.INVALID_PAGE_REQUEST);
         }
         ProblemListDto problemListDto = problemService.getProblemList(pageParamRequest.toServiceDto());
-        return ApiResponse.ok(ProblemSuccessCode.SUCCESS_GET_PROBLEMS, PageResponse.of(problemListDto.problems(),
+        return ApiResponse.ok(ProblemSuccessCode.SUCCESS_GET_PROBLEM_LIST, PageResponse.of(problemListDto.problems(),
             problemListDto.pageInfo()));
     }
 

--- a/til-api/src/main/java/com/til/controller/problem/Response/ProblemInfoResponse.java
+++ b/til-api/src/main/java/com/til/controller/problem/Response/ProblemInfoResponse.java
@@ -1,0 +1,36 @@
+package com.til.controller.problem.Response;
+
+import com.til.domain.problem.dto.ProblemInfoDto;
+
+import lombok.Builder;
+
+@Builder
+public record ProblemInfoResponse(
+                                  Long id,
+                                  String title,
+                                  String question,
+                                  String solution,
+                                  int point,
+                                  int level,
+                                  int solved,
+                                  double percentage,
+                                  String categoryName,
+                                  String topic
+) {
+
+    public static ProblemInfoResponse of(ProblemInfoDto problemInfoDto) {
+
+        return ProblemInfoResponse.builder()
+            .id(problemInfoDto.id())
+            .title(problemInfoDto.title())
+            .question(problemInfoDto.question())
+            .solution(problemInfoDto.solution())
+            .point(problemInfoDto.point())
+            .level(problemInfoDto.level())
+            .solved(problemInfoDto.solved())
+            .percentage(problemInfoDto.percentage())
+            .categoryName(problemInfoDto.categoryName())
+            .topic(problemInfoDto.topic())
+            .build();
+    }
+}

--- a/til-domain/src/main/java/com/til/application/problem/ProblemService.java
+++ b/til-domain/src/main/java/com/til/application/problem/ProblemService.java
@@ -6,7 +6,10 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.til.domain.common.dto.PageParamDto;
+import com.til.domain.common.exception.BaseException;
+import com.til.domain.problem.dto.ProblemInfoDto;
 import com.til.domain.problem.dto.ProblemListDto;
+import com.til.domain.problem.enums.ProblemErrorCode;
 import com.til.domain.problem.model.Problem;
 import com.til.domain.problem.repository.ProblemRepository;
 
@@ -23,6 +26,12 @@ public class ProblemService {
         Pageable pageable = pageParamDto.toPageable();
         Page<Problem> problems = problemRepository.findAll(pageable);
         return ProblemListDto.of(problems);
+    }
+
+    public ProblemInfoDto getProblemInfo(Long id) {
+        Problem problem = problemRepository.findById(id)
+            .orElseThrow(() -> new BaseException(ProblemErrorCode.NOT_FOUND_PROBLEM));
+        return ProblemInfoDto.of(problem);
     }
 
 }

--- a/til-domain/src/main/java/com/til/domain/problem/dto/ProblemInfoDto.java
+++ b/til-domain/src/main/java/com/til/domain/problem/dto/ProblemInfoDto.java
@@ -1,6 +1,8 @@
 package com.til.domain.problem.dto;
 
-import com.til.domain.category.dto.CategoryDto;
+import com.til.domain.category.model.Category;
+import com.til.domain.category.model.ProblemCategory;
+import com.til.domain.problem.model.Problem;
 
 import lombok.Builder;
 
@@ -10,11 +12,29 @@ public record ProblemInfoDto(
                              String title,
                              String question,
                              String solution,
-                             Integer point,
-                             Integer level,
-                             Integer solved,
-                             Float percentage,
-                             CategoryDto category
+                             int point,
+                             int level,
+                             int solved,
+                             double percentage,
+                             String categoryName,
+                             String topic
 ) {
 
+    public static ProblemInfoDto of(Problem problem) {
+        ProblemCategory problemCategory = problem.getProblemCategorySet().stream().findFirst().orElse(null);
+        Category category = (problemCategory != null) ? problemCategory.getCategory() : null;
+
+        return ProblemInfoDto.builder()
+            .id(problem.getId())
+            .title(problem.getTitle())
+            .question(problem.getQuestion())
+            .solution(problem.getSolution())
+            .point(problem.getPoint())
+            .level(problem.getLevel())
+            .solved(problem.getSolved())
+            .percentage(problem.getPercentage())
+            .categoryName(category != null ? category.getName() : null)
+            .topic(category != null ? category.getTopic() : null)
+            .build();
+    }
 }

--- a/til-domain/src/main/java/com/til/domain/problem/enums/ProblemErrorCode.java
+++ b/til-domain/src/main/java/com/til/domain/problem/enums/ProblemErrorCode.java
@@ -1,0 +1,19 @@
+package com.til.domain.problem.enums;
+
+import org.springframework.http.HttpStatus;
+
+import com.til.domain.common.enums.ErrorCode;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public enum ProblemErrorCode implements ErrorCode {
+
+    NOT_FOUND_PROBLEM(HttpStatus.NOT_FOUND, "존재하지 않는 문제입니다.");
+
+    private final HttpStatus status;
+    private final String message;
+}

--- a/til-domain/src/main/java/com/til/domain/problem/enums/ProblemSuccessCode.java
+++ b/til-domain/src/main/java/com/til/domain/problem/enums/ProblemSuccessCode.java
@@ -10,7 +10,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 public enum ProblemSuccessCode implements SuccessCode {
 
-    SUCCESS_GET_PROBLEMS("문제 리스트를 성공적으로 가져왔습니다."),
+    SUCCESS_GET_PROBLEM_LIST("문제 리스트를 성공적으로 가져왔습니다."),
     SUCCESS_GET_PROBLEM_INFO("문제 상세 정보를 성공적으로 가져왔습니다.");
 
     private final String message;

--- a/til-domain/src/main/java/com/til/domain/problem/enums/ProblemSuccessCode.java
+++ b/til-domain/src/main/java/com/til/domain/problem/enums/ProblemSuccessCode.java
@@ -10,7 +10,8 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 public enum ProblemSuccessCode implements SuccessCode {
 
-    SUCCESS_GET_PROBLEMS("문제 리스트를 성공적으로 가져왔습니다.");
+    SUCCESS_GET_PROBLEMS("문제 리스트를 성공적으로 가져왔습니다."),
+    SUCCESS_GET_PROBLEM_INFO("문제 상세 정보를 성공적으로 가져왔습니다.");
 
     private final String message;
 }

--- a/til-domain/src/test/java/com/til/application/problem/ProblemServiceTest.java
+++ b/til-domain/src/test/java/com/til/application/problem/ProblemServiceTest.java
@@ -5,6 +5,7 @@ import static org.mockito.BDDMockito.*;
 
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.Optional;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -16,7 +17,10 @@ import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 
 import com.til.domain.common.dto.PageParamDto;
+import com.til.domain.common.exception.BaseException;
+import com.til.domain.problem.dto.ProblemInfoDto;
 import com.til.domain.problem.dto.ProblemListDto;
+import com.til.domain.problem.enums.ProblemErrorCode;
 import com.til.domain.problem.model.Problem;
 import com.til.domain.problem.repository.ProblemRepository;
 
@@ -49,6 +53,37 @@ public class ProblemServiceTest {
         // then
         assertThat(result).isNotNull();
         assertThat(result.problems().get(0).id()).isEqualTo(problem.getId());
+        assertThat(result.problems().get(0).title()).isEqualTo(problem.getTitle());
+    }
+
+    @Test
+    void 문제_상세정보를_정상적으로_반환한다() {
+        // given
+        Long problemId = 1L;
+        Problem problem = createProblem();
+        given(problemRepository.findById(problemId)).willReturn(Optional.of(problem));
+
+        // when
+        ProblemInfoDto result = problemService.getProblemInfo(problemId);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.id()).isEqualTo(problem.getId());
+        assertThat(result.title()).isEqualTo(problem.getTitle());
+    }
+
+    @Test
+    void 문제를_찾지_못했을_경우_예외를_던진다() {
+        // given
+        Long problemId = 1L;
+        given(problemRepository.findById(problemId)).willReturn(Optional.empty());
+
+        // when
+        Throwable thrown = catchThrowable(() -> problemService.getProblemInfo(problemId));
+
+        // then
+        assertThat(thrown).isInstanceOf(BaseException.class)
+            .hasMessage(ProblemErrorCode.NOT_FOUND_PROBLEM.getMessage());
     }
 
     private Problem createProblem() {


### PR DESCRIPTION
## 이슈 번호(링크)

[TIL-100](https://soma-til.atlassian.net/browse/TIL-100)

<br>

## 개요

- 기술학습 문제 상세 정보 조회

<br>

## 내용

- 문제 상세 정보 조회 로직 구현
- SuccessCode 및 ErrorCode 추가
- ProblemServiceTest 테스트 코드 추가

<br>

## 리뷰어한테 할 말
- Response 결과 예시입니다. 
<img width="578" alt="스크린샷 2024-07-30 오전 3 04 46" src="https://github.com/user-attachments/assets/4ea55bc4-50fb-4664-9d8b-70a63c8b5e22">
<img width="285" alt="image" src="https://github.com/user-attachments/assets/5694f4fb-2b8b-4fd1-a42a-757ef21a5744">




[TIL-100]: https://soma-til.atlassian.net/browse/TIL-100?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ