### PR TITLE
[TIL-107] Category 리스트 조회 API 추가

### DIFF
--- a/db/dummy-category.sql
+++ b/db/dummy-category.sql
@@ -1,0 +1,17 @@
+insert into category (name, topic, created_date, modified_date)
+values
+  -- 네트워크
+    ("네트워크", "HTTP", now(), now()),
+    ("네트워크", "OSI 7계층", now(), now()),
+    ("네트워크", "Transport 계층", now(), now()),
+  -- 데이터베이스
+    ("데이터베이스", "트랜잭션", now(), now()),
+    ("데이터베이스", "인덱스", now(), now()),
+  -- 자료구조
+    ("자료구조", "해시", now(), now()),
+    ("자료구조", "이진 탐색 트리", now(), now()),
+    ("자료구조", "연결 리스트", now(), now()),
+  -- 운영체제
+    ("운영체제", "프로세스와 스레드", now(), now()),
+    ("운영체제", "동시성", now(), now()),
+    ("운영체제", "페이징", now(), now());

--- a/til-api/src/main/java/com/til/controller/category/CategoryController.java
+++ b/til-api/src/main/java/com/til/controller/category/CategoryController.java
@@ -1,0 +1,29 @@
+package com.til.controller.category;
+
+import java.util.List;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.til.application.category.CategoryService;
+import com.til.common.response.ApiResponse;
+import com.til.controller.category.response.CategoryListResponse;
+import com.til.domain.category.dto.CategoryDto;
+import com.til.domain.category.enums.CategorySuccessCode;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/category")
+public class CategoryController {
+
+    private final CategoryService categoryService;
+
+    @GetMapping("")
+    public ApiResponse<CategoryListResponse> getCategoryList() {
+        List<CategoryDto> categoryList = categoryService.getCategoryList();
+        return ApiResponse.ok(CategorySuccessCode.SUCCESS_GET_CATEGORY_LIST, CategoryListResponse.of(categoryList));
+    }
+}

--- a/til-api/src/main/java/com/til/controller/category/response/CategoryListResponse.java
+++ b/til-api/src/main/java/com/til/controller/category/response/CategoryListResponse.java
@@ -1,0 +1,14 @@
+package com.til.controller.category.response;
+
+import java.util.List;
+
+import com.til.domain.category.dto.CategoryDto;
+
+public record CategoryListResponse(
+                                   List<CategoryDto> categoryList
+) {
+
+    public static CategoryListResponse of(List<CategoryDto> categoryList) {
+        return new CategoryListResponse(categoryList);
+    }
+}

--- a/til-domain/src/main/java/com/til/application/category/CategoryService.java
+++ b/til-domain/src/main/java/com/til/application/category/CategoryService.java
@@ -1,0 +1,29 @@
+package com.til.application.category;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.til.domain.category.dto.CategoryDto;
+import com.til.domain.category.model.Category;
+import com.til.domain.category.repository.CategoryRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CategoryService {
+
+    private final CategoryRepository categoryRepository;
+
+    public List<CategoryDto> getCategoryList() {
+        List<Category> categoryList = categoryRepository.findAll();
+
+        return categoryList.stream()
+            .map(CategoryDto::of)
+            .collect(Collectors.toList());
+    }
+}

--- a/til-domain/src/main/java/com/til/domain/category/dto/CategoryDto.java
+++ b/til-domain/src/main/java/com/til/domain/category/dto/CategoryDto.java
@@ -1,5 +1,7 @@
 package com.til.domain.category.dto;
 
+import com.til.domain.category.model.Category;
+
 import lombok.Builder;
 
 @Builder
@@ -8,4 +10,10 @@ public record CategoryDto(
                           String topic
 ) {
 
+    public static CategoryDto of(Category category) {
+        return CategoryDto.builder()
+            .name(category.getName())
+            .topic(category.getTopic())
+            .build();
+    }
 }

--- a/til-domain/src/main/java/com/til/domain/category/enums/CategorySuccessCode.java
+++ b/til-domain/src/main/java/com/til/domain/category/enums/CategorySuccessCode.java
@@ -1,0 +1,17 @@
+package com.til.domain.category.enums;
+
+import com.til.domain.common.enums.SuccessCode;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public enum CategorySuccessCode implements SuccessCode {
+
+    SUCCESS_GET_CATEGORY_LIST("카테고리 리스트를 성공적으로 가져왔습니다.");
+
+    private final String message;
+
+}

--- a/til-domain/src/test/java/com/til/application/category/CategoryServiceTest.java
+++ b/til-domain/src/test/java/com/til/application/category/CategoryServiceTest.java
@@ -1,0 +1,61 @@
+package com.til.application.category;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.til.domain.category.dto.CategoryDto;
+import com.til.domain.category.model.Category;
+import com.til.domain.category.repository.CategoryRepository;
+
+@ExtendWith(MockitoExtension.class)
+public class CategoryServiceTest {
+
+    @InjectMocks
+    private CategoryService categoryService;
+
+    @Mock
+    private CategoryRepository categoryRepository;
+
+    @Test
+    void 카테고리_리스트를_정상적으로_반환한다() {
+        // given
+        int size = 10;
+        List<Category> categoryList = createCategoryList(size);
+
+        given(categoryRepository.findAll()).willReturn(categoryList);
+
+        // when
+        List<CategoryDto> categoryDtoList = categoryService.getCategoryList();
+
+        // then
+        assertThat(categoryDtoList.size()).isEqualTo(size);
+    }
+
+    private List<Category> createCategoryList(int size) {
+        List<Category> categoryList = new ArrayList<>();
+
+        for (int i = 0; i < size; i++) {
+            categoryList.add(createCategory());
+        }
+
+        return categoryList;
+    }
+
+    private Category createCategory() {
+        return Category.builder()
+            .id(1L)
+            .name("NETWORK")
+            .topic("HTTP")
+            .build();
+    }
+
+}


### PR DESCRIPTION
## 이슈 번호(링크)

[TIL-107](https://soma-til.atlassian.net/browse/TIL-107)

<br>

## 개요

- 모의면접 구성 코드 작성

<br>

## 내용

- dummy-category.sql 더미 데이터 추가
- Category 리스트 서비스 코드 작성
- Category 리스트 컨트롤러 코드 작성
- Category 리스트 조회 API, 테스트 작성

<br>

## 리뷰어한테 할 말

전체 카테고리 리스트를 가져오는 경우에 대해서는 에러가 나는 경우는 INTERNAL_SERVER_ERROR 경우밖에 없을 것 같아서 ErrorCode를 따로 작성하진 않았습니다.


[TIL-107]: https://soma-til.atlassian.net/browse/TIL-107?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ