### PR TITLE
[TIL-120] 기술학습 문제 즐겨찾기 추가/삭제 API 구현

### DIFF
--- a/db/dummy-problem.sql
+++ b/db/dummy-problem.sql
@@ -1,0 +1,22 @@
+INSERT INTO problem (title, question, solution, point, level, solved, percentage, created_date, modified_date)
+VALUES
+    ('Solve for x', 'What is the value of x in the equation 2x + 3 = 7?', 'x = 2', 10, 1, 100, 90.0, NOW(), NOW()),
+    ('Find the area', 'What is the area of a triangle with base 5 and height 3?', 'Area = 7.5', 15, 1, 150, 95.0, NOW(), NOW()),
+    ('Sort an array', 'Sort the given array in ascending order.', 'Use quicksort algorithm', 20, 2, 200, 85.0, NOW(), NOW()),
+    ('Binary Search', 'Find the position of target value in a sorted array using binary search.', 'Use binary search algorithm', 25, 2, 250, 80.0, NOW(), NOW()),
+    ('Calculate velocity', 'What is the velocity of an object moving with constant acceleration?', 'Use v = u + at', 15, 1, 180, 88.0, NOW(), NOW()),
+    ('Ohm\'s Law', 'Calculate the current in a circuit with resistance R and voltage V.', 'Use I = V/R', 20, 1, 160, 92.0, NOW(), NOW()),
+    ('Functional Groups', 'Identify the functional groups in the given organic molecule.', 'List the functional groups', 15, 2, 140, 87.0, NOW(), NOW()),
+    ('Periodic Table', 'Identify the elements in the given group of the periodic table.', 'List the elements', 10, 1, 120, 91.0, NOW(), NOW()),
+    ('Punnett Square', 'Determine the genotypic ratio for the given cross.', 'Draw the Punnett square', 15, 1, 130, 89.0, NOW(), NOW()),
+    ('Natural Selection', 'Explain the principle of natural selection.', 'Describe how natural selection works', 20, 2, 110, 85.0, NOW(), NOW()),
+    ('Matrix Multiplication', 'Multiply the given matrices.', 'Provide the resulting matrix', 25, 2, 170, 83.0, NOW(), NOW()),
+    ('Pythagorean Theorem', 'Find the length of the hypotenuse in a right triangle with legs a and b.', 'Use c = sqrt(a^2 + b^2)', 10, 1, 140, 94.0, NOW(), NOW()),
+    ('Dijkstra\'s Algorithm', 'Find the shortest path in the given graph.', 'Use Dijkstra\'s algorithm', 30, 3, 90, 82.0, NOW(), NOW()),
+    ('Linked List', 'Implement a singly linked list.', 'Provide the implementation code', 20, 2, 160, 86.0, NOW(), NOW()),
+    ('Newton\'s Second Law', 'Calculate the force on an object with mass m and acceleration a.', 'Use F = ma', 15, 1, 150, 90.0, NOW(), NOW()),
+    ('Faraday\'s Law', 'Calculate the induced emf in a coil with N turns and changing magnetic flux.', 'Use emf = -N dΦ/dt', 25, 2, 130, 88.0, NOW(), NOW()),
+    ('Reaction Mechanism', 'Determine the mechanism of the given organic reaction.', 'Provide the step-by-step mechanism', 20, 3, 120, 84.0, NOW(), NOW()),
+    ('Chemical Bonding', 'Explain the type of bonding in the given compound.', 'Describe the bonding type', 15, 1, 170, 93.0, NOW(), NOW()),
+    ('Genetic Code', 'Translate the given mRNA sequence into an amino acid sequence.', 'Use the genetic code table', 20, 2, 180, 87.0, NOW(), NOW()),
+    ('Evolutionary Trees', 'Construct an evolutionary tree based on the given data.', 'Draw the evolutionary tree', 25, 3, 140, 81.0, NOW(), NOW());

--- a/til-api/src/main/java/com/til/controller/problem/ProblemController.java
+++ b/til-api/src/main/java/com/til/controller/problem/ProblemController.java
@@ -3,13 +3,17 @@ package com.til.controller.problem;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.til.application.problem.ProblemService;
+import com.til.common.annotation.CurrentUser;
 import com.til.common.page.PageParamRequest;
 import com.til.common.page.PageResponse;
 import com.til.common.response.ApiResponse;
+import com.til.controller.problem.request.FavoriteProblemRequest;
 import com.til.controller.problem.response.ProblemInfoResponse;
 import com.til.domain.common.enums.BaseErrorCode;
 import com.til.domain.common.exception.BaseException;
@@ -17,6 +21,7 @@ import com.til.domain.problem.dto.ProblemInfoDto;
 import com.til.domain.problem.dto.ProblemListDto;
 import com.til.domain.problem.dto.ProblemListInfoDto;
 import com.til.domain.problem.enums.ProblemSuccessCode;
+import com.til.domain.user.dto.UserInfoDto;
 
 import lombok.RequiredArgsConstructor;
 
@@ -42,6 +47,13 @@ public class ProblemController {
     public ApiResponse<ProblemInfoResponse> getProblemInfo(@PathVariable Long id) {
         ProblemInfoDto problemInfoDto = problemService.getProblemInfo(id);
         return ApiResponse.ok(ProblemSuccessCode.SUCCESS_GET_PROBLEM_INFO, ProblemInfoResponse.of(problemInfoDto));
+    }
+
+    @PostMapping("/{id}/favorite")
+    public ApiResponse<Void> favoriteProblem(@CurrentUser UserInfoDto userInfo, @PathVariable Long id,
+        @RequestBody FavoriteProblemRequest favoriteProblemRequest) {
+        problemService.toggleFavorite(favoriteProblemRequest.toServiceDto(userInfo.id(), id));
+        return ApiResponse.ok();
     }
 
 }

--- a/til-api/src/main/java/com/til/controller/problem/request/FavoriteProblemRequest.java
+++ b/til-api/src/main/java/com/til/controller/problem/request/FavoriteProblemRequest.java
@@ -1,0 +1,18 @@
+package com.til.controller.problem.request;
+
+import com.til.domain.problem.dto.FavoriteProblemDto;
+
+import jakarta.validation.constraints.NotNull;
+
+public record FavoriteProblemRequest(
+                                     @NotNull Boolean isFavorite
+) {
+
+    public FavoriteProblemDto toServiceDto(Long userId, Long problemId) {
+        return FavoriteProblemDto.builder()
+            .isFavorite(isFavorite)
+            .userId(userId)
+            .problemId(problemId)
+            .build();
+    }
+}

--- a/til-domain/src/main/java/com/til/domain/problem/dto/FavoriteProblemDto.java
+++ b/til-domain/src/main/java/com/til/domain/problem/dto/FavoriteProblemDto.java
@@ -1,0 +1,20 @@
+package com.til.domain.problem.dto;
+
+import com.til.domain.problem.model.FavoriteProblem;
+
+import lombok.Builder;
+
+@Builder
+public record FavoriteProblemDto(
+                                 boolean isFavorite,
+                                 Long userId,
+                                 Long problemId
+) {
+
+    public FavoriteProblem toEntity() {
+        return FavoriteProblem.builder()
+            .userId(userId)
+            .problemId(problemId)
+            .build();
+    }
+}

--- a/til-domain/src/main/java/com/til/domain/problem/enums/ProblemErrorCode.java
+++ b/til-domain/src/main/java/com/til/domain/problem/enums/ProblemErrorCode.java
@@ -12,7 +12,9 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 public enum ProblemErrorCode implements ErrorCode {
 
-    NOT_FOUND_PROBLEM(HttpStatus.NOT_FOUND, "존재하지 않는 문제입니다.");
+    NOT_FOUND_PROBLEM(HttpStatus.NOT_FOUND, "존재하지 않는 문제입니다."),
+    ALREADY_FAVORITE_PROBLEM(HttpStatus.BAD_REQUEST, "이미 즐겨찾기한 문제입니다."),
+    NOT_FOUND_FAVORITE_PROBLEM(HttpStatus.BAD_REQUEST, "즐겨찾기한 문제가 존재하지 않습니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/til-domain/src/main/java/com/til/domain/problem/model/FavoriteProblem.java
+++ b/til-domain/src/main/java/com/til/domain/problem/model/FavoriteProblem.java
@@ -1,0 +1,32 @@
+package com.til.domain.problem.model;
+
+import com.til.domain.common.model.BaseTimeEntity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+@Entity
+@Getter
+@SuperBuilder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "favorite_problem")
+public class FavoriteProblem extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private Long userId;
+
+    @Column(nullable = false)
+    private Long problemId;
+}

--- a/til-domain/src/main/java/com/til/domain/problem/repository/FavoriteProblemRepository.java
+++ b/til-domain/src/main/java/com/til/domain/problem/repository/FavoriteProblemRepository.java
@@ -1,0 +1,12 @@
+package com.til.domain.problem.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.til.domain.problem.model.FavoriteProblem;
+
+public interface FavoriteProblemRepository extends JpaRepository<FavoriteProblem, Long> {
+
+    boolean existsByUserIdAndProblemId(Long userId, Long problemId);
+
+    void deleteByUserIdAndProblemId(Long userId, Long problemId);
+}


### PR DESCRIPTION
## 이슈 번호(링크)

[TIL-120](https://soma-til.atlassian.net/browse/TIL-120)

<br>

## 개요
기술학습 문제 즐겨찾기 추가/삭제 API 구현

<br>

## 내용
- 기술학습 문제 즐겨찾기 API
  - 하나의 API에서 request body의 `isFavorite`의 값을 통해 즐겨찾기 추가/삭제 진행
  - 성공/실패시 Response
    <img src="https://github.com/user-attachments/assets/22404b47-67f3-48db-94c9-beeede3e1ddd" width=500 />
  - 참고 : [기술학습 문제 즐겨찾기 API 문서](https://soma-til.notion.site/26cbf7915c56472e89eb9381a36a85a3)

- problem dummy insert 스크립트 추가

<br>

## 리뷰어한테 할 말
🍋


[TIL-120]: https://soma-til.atlassian.net/browse/TIL-120?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ