### PR TITLE
[TIL-160] 비밀번호 변경 API 구현

### DIFF
--- a/til-api/src/main/java/com/til/controller/user/UserController.java
+++ b/til-api/src/main/java/com/til/controller/user/UserController.java
@@ -1,6 +1,7 @@
 package com.til.controller.user;
 
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -13,6 +14,7 @@ import com.til.common.annotation.CurrentUser;
 import com.til.common.response.ApiResponse;
 import com.til.controller.user.request.UserJoinRequest;
 import com.til.controller.user.request.UserLoginRequest;
+import com.til.controller.user.request.UserPasswordRequest;
 import com.til.controller.user.response.UserLoginResponse;
 import com.til.domain.auth.dto.AuthTokenDto;
 import com.til.domain.auth.dto.AuthUserInfoDto;
@@ -54,5 +56,12 @@ public class UserController {
     public ApiResponse<Void> checkNickname(@PathVariable String nickname) {
         userService.checkNickname(nickname);
         return ApiResponse.ok(UserSuccessCode.POSSIBLE_NICKNAME);
+    }
+
+    @PatchMapping("/change-password")
+    public ApiResponse<Void> changePassword(@CurrentUser UserInfoDto userInfo,
+        @RequestBody @Valid UserPasswordRequest request) {
+        userService.changePassword(userInfo.id(), request.toServiceDto());
+        return ApiResponse.ok(UserSuccessCode.SUCCESS_CHANGE_PASSWORD);
     }
 }

--- a/til-api/src/main/java/com/til/controller/user/request/UserPasswordRequest.java
+++ b/til-api/src/main/java/com/til/controller/user/request/UserPasswordRequest.java
@@ -1,0 +1,18 @@
+package com.til.controller.user.request;
+
+import org.apache.logging.log4j.core.config.plugins.validation.constraints.NotBlank;
+
+import com.til.domain.user.dto.UserPasswordDto;
+
+public record UserPasswordRequest(
+                                  @NotBlank(message = "비밀번호는 필수 입력 값 입니다.") String password,
+                                  @NotBlank(message = "변경할 비밀번호는 필수 입력 값 입니다.") String newPassword
+) {
+
+    public UserPasswordDto toServiceDto() {
+        return UserPasswordDto.builder()
+            .password(password)
+            .newPassword(newPassword)
+            .build();
+    }
+}

--- a/til-domain/src/main/java/com/til/domain/user/dto/UserPasswordDto.java
+++ b/til-domain/src/main/java/com/til/domain/user/dto/UserPasswordDto.java
@@ -1,0 +1,10 @@
+package com.til.domain.user.dto;
+
+import lombok.Builder;
+
+@Builder
+public record UserPasswordDto(
+                              String password,
+                              String newPassword
+) {
+}

--- a/til-domain/src/main/java/com/til/domain/user/enums/UserErrorCode.java
+++ b/til-domain/src/main/java/com/til/domain/user/enums/UserErrorCode.java
@@ -15,7 +15,10 @@ public enum UserErrorCode implements ErrorCode {
     ALREADY_EXISTS_NICKNAME(HttpStatus.BAD_REQUEST, "이미 존재하는 닉네임입니다."),
     ALREADY_EXISTS_EMAIL(HttpStatus.BAD_REQUEST, "이미 존재하는 이메일입니다."),
     FAILED_LOGIN(HttpStatus.BAD_REQUEST, "로그인에 실패했습니다."),
-    NOT_FOUND_USER(HttpStatus.NOT_FOUND, "해당 사용자를 찾을 수 없습니다.");
+    NOT_FOUND_USER(HttpStatus.NOT_FOUND, "해당 사용자를 찾을 수 없습니다."),
+    NOT_MATCH_PASSWORD(HttpStatus.BAD_REQUEST, "비밀번호가 일치하지 않습니다."),
+    SAME_PASSWORD(HttpStatus.BAD_REQUEST, "기존 비밀번호와 동일합니다."),
+    ;
 
     private final HttpStatus status;
     private final String message;

--- a/til-domain/src/main/java/com/til/domain/user/enums/UserSuccessCode.java
+++ b/til-domain/src/main/java/com/til/domain/user/enums/UserSuccessCode.java
@@ -13,7 +13,8 @@ public enum UserSuccessCode implements SuccessCode {
     SUCCESS_JOIN("회원가입에 성공하였습니다."),
     SUCCESS_LOGIN("로그인에 성공하였습니다."),
     POSSIBLE_NICKNAME("사용 가능한 닉네임입니다."),
-    SUCCESS_LOGOUT("로그아웃에 성공하였습니다.");
+    SUCCESS_LOGOUT("로그아웃에 성공하였습니다."),
+    SUCCESS_CHANGE_PASSWORD("비밀번호 변경이 성공적으로 완료되었습니다.");
 
     private final String message;
 }

--- a/til-domain/src/main/java/com/til/domain/user/model/User.java
+++ b/til-domain/src/main/java/com/til/domain/user/model/User.java
@@ -13,6 +13,7 @@ import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 import lombok.experimental.SuperBuilder;
 
 @Entity
@@ -30,6 +31,7 @@ public class User extends BaseTimeEntity {
     private String email;
 
     @Column(nullable = false)
+    @Setter
     private String password;
 
     @Column(nullable = false)
@@ -46,8 +48,4 @@ public class User extends BaseTimeEntity {
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private Status status;
-
-    public void setPassword(String password) {
-        this.password = password;
-    }
 }

--- a/til-domain/src/main/java/com/til/domain/user/repository/UserRepositoryCustom.java
+++ b/til-domain/src/main/java/com/til/domain/user/repository/UserRepositoryCustom.java
@@ -9,4 +9,8 @@ public interface UserRepositoryCustom {
     boolean existsByNickname(String nickname);
 
     User getByEmail(String email);
+
+    String getPasswordById(Long id);
+
+    void updatePassword(Long id, String password);
 }

--- a/til-domain/src/main/java/com/til/domain/user/repository/UserRepositoryCustomImpl.java
+++ b/til-domain/src/main/java/com/til/domain/user/repository/UserRepositoryCustomImpl.java
@@ -40,4 +40,22 @@ public class UserRepositoryCustomImpl implements UserRepositoryCustom {
                 .fetchOne()
         ).orElseThrow(() -> new BaseException(UserErrorCode.NOT_FOUND_USER));
     }
+
+    @Override
+    public String getPasswordById(Long id) {
+        return Optional.ofNullable(
+            queryFactory.select(user.password)
+                .from(user)
+                .where(user.id.eq(id))
+                .fetchOne()
+        ).orElseThrow(() -> new BaseException(UserErrorCode.NOT_FOUND_USER));
+    }
+
+    @Override
+    public void updatePassword(Long id, String password) {
+        queryFactory.update(user)
+            .set(user.password, password)
+            .where(user.id.eq(id))
+            .execute();
+    }
 }

--- a/til-domain/src/test/java/com/til/application/user/UserServiceTest.java
+++ b/til-domain/src/test/java/com/til/application/user/UserServiceTest.java
@@ -1,17 +1,21 @@
 package com.til.application.user;
 
-import static org.assertj.core.api.AssertionsForClassTypes.*;
-import static org.mockito.BDDMockito.*;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.anyString;
+import static org.mockito.BDDMockito.given;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
 
 import com.til.domain.common.exception.BaseException;
 import com.til.domain.user.dto.UserJoinDto;
 import com.til.domain.user.dto.UserLoginDto;
+import com.til.domain.user.dto.UserPasswordDto;
 import com.til.domain.user.enums.UserErrorCode;
 import com.til.domain.user.repository.UserRepository;
 import com.til.domain.user.validator.UserInfoValidator;
@@ -24,6 +28,9 @@ class UserServiceTest {
 
     @Mock
     private UserInfoValidator userInfoValidator;
+
+    @Mock
+    private PasswordEncoder passwordEncoder;
 
     @Mock
     private UserRepository userRepository;
@@ -65,6 +72,32 @@ class UserServiceTest {
             .isEqualTo(UserErrorCode.NOT_FOUND_USER);
     }
 
+    @Test
+    void 비밀번호_변경시_기존_비밀번호_정보가_유효하지_않으면_예외를_던진다() {
+        // given
+        given(userRepository.getPasswordById(anyLong())).willReturn("otherPassword");
+        given(passwordEncoder.matches(anyString(), anyString())).willReturn(false);
+
+        // when & then
+        assertThatThrownBy(() -> userService.changePassword(1L, createUserPasswordDto("pass1234", "new12345")))
+            .isInstanceOf(BaseException.class)
+            .extracting(error -> ((BaseException) error).getErrorCode())
+            .isEqualTo(UserErrorCode.NOT_MATCH_PASSWORD);
+    }
+
+    @Test
+    void 비밀번호_변경시_새로운_비밀번호가_기존_비밀번호와_같으면_예외를_던진다() {
+        // given
+        given(userRepository.getPasswordById(anyLong())).willReturn("pass1234");
+        given(passwordEncoder.matches(anyString(), anyString())).willReturn(true);
+
+        // when & then
+        assertThatThrownBy(() -> userService.changePassword(1L, createUserPasswordDto("pass1234", "pass1234")))
+            .isInstanceOf(BaseException.class)
+            .extracting(error -> ((BaseException) error).getErrorCode())
+            .isEqualTo(UserErrorCode.SAME_PASSWORD);
+    }
+
     private UserJoinDto createUserJoinDto() {
         return UserJoinDto.builder()
             .email("test@til.com")
@@ -77,6 +110,13 @@ class UserServiceTest {
         return UserLoginDto.builder()
             .email("test@til.com")
             .password("soma2024")
+            .build();
+    }
+
+    private UserPasswordDto createUserPasswordDto(String password, String newPassword) {
+        return UserPasswordDto.builder()
+            .password(password)
+            .newPassword(newPassword)
             .build();
     }
 }


### PR DESCRIPTION
## 이슈 번호(링크)

[TIL-160](https://soma-til.atlassian.net/browse/TIL-160)

<br>

## 개요
비밀번호 변경 API 구현

<br>

## 내용
- 비밀번호 변경 API 구현
- 비밀번호 변경 API 구현하면서 중복 로직 리팩토링
  - passwordEncoder.matches, passwordEncoder.encode 메서드로 분리
  - User Entity setPassword 메서드 @Setter로 대체
- 참고 : [비밀번호 변경 API 문서](https://soma-til.notion.site/a25020b643bc457b96ff8c1e4c363754)

<br>

## 리뷰어한테 할 말
💡


[TIL-160]: https://soma-til.atlassian.net/browse/TIL-160?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ