### PR TITLE
[TIL-127] 모의 면접 생성 기능 구현

### DIFF
--- a/db/table_ddl.sql
+++ b/db/table_ddl.sql
@@ -1,4 +1,4 @@
-DROP TABLE IF EXISTS user, category, favorite_problem, problem, problem_category, solve_problem;
+DROP TABLE IF EXISTS user, category, favorite_problem, problem, problem_category, solve_problem, interview;
 
 CREATE TABLE user
 (
@@ -61,4 +61,14 @@ CREATE TABLE solve_problem
     status        enum ('PASS', 'FAIL', 'PENDING') not null,
     created_date  datetime(6)                      not null,
     modified_date datetime(6)                      not null
+);
+
+CREATE TABLE interview
+(
+  id            bigint auto_increment primary key,
+  uuid          varchar(20) not null,
+  status        enum ('PROCESSING', 'DONE', 'ABORTED') not null,
+  user_id       bigint not null,
+  created_date  datetime(6)                      not null,
+  modified_date datetime(6)                      not null
 );

--- a/til-api/src/main/java/com/til/controller/interview/InterviewController.java
+++ b/til-api/src/main/java/com/til/controller/interview/InterviewController.java
@@ -1,0 +1,35 @@
+package com.til.controller.interview;
+
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.til.application.interview.InterviewService;
+import com.til.common.annotation.CurrentUser;
+import com.til.common.response.ApiResponse;
+import com.til.controller.interview.request.InterviewCreateRequest;
+import com.til.controller.interview.response.InterviewUuidResponse;
+import com.til.domain.interview.dto.InterviewUuidDto;
+import com.til.domain.interview.enums.InterviewSuccessCode;
+import com.til.domain.user.dto.UserInfoDto;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/interview")
+public class InterviewController {
+
+    private final InterviewService interviewService;
+
+    @PostMapping("/create")
+    public ApiResponse<InterviewUuidResponse> createInterview(@CurrentUser UserInfoDto userInfo,
+        @RequestBody InterviewCreateRequest request) {
+        InterviewUuidDto interviewUuidDto = interviewService.create(request.toServiceDto(userInfo.id()));
+
+        return ApiResponse.ok(InterviewSuccessCode.SUCCESS_INTERVIEW_CREATION, InterviewUuidResponse.of(
+            interviewUuidDto));
+    }
+
+}

--- a/til-api/src/main/java/com/til/controller/interview/request/InterviewCreateRequest.java
+++ b/til-api/src/main/java/com/til/controller/interview/request/InterviewCreateRequest.java
@@ -1,0 +1,20 @@
+package com.til.controller.interview.request;
+
+import java.util.List;
+
+import com.til.domain.category.dto.CategoryDto;
+import com.til.domain.interview.dto.InterviewCreateDto;
+
+public record InterviewCreateRequest(
+                                     List<CategoryDto> categoryList,
+                                     Long userId
+) {
+
+    public InterviewCreateDto toServiceDto(Long userId) {
+        return InterviewCreateDto.builder()
+            .categoryList(categoryList)
+            .userId(userId)
+            .build();
+
+    }
+}

--- a/til-api/src/main/java/com/til/controller/interview/response/InterviewUuidResponse.java
+++ b/til-api/src/main/java/com/til/controller/interview/response/InterviewUuidResponse.java
@@ -1,0 +1,12 @@
+package com.til.controller.interview.response;
+
+import com.til.domain.interview.dto.InterviewUuidDto;
+
+public record InterviewUuidResponse(
+                                    InterviewUuidDto interviewUuid
+) {
+
+    public static InterviewUuidResponse of(InterviewUuidDto interviewUuid) {
+        return new InterviewUuidResponse(interviewUuid);
+    }
+}

--- a/til-domain/src/main/java/com/til/application/interview/InterviewService.java
+++ b/til-domain/src/main/java/com/til/application/interview/InterviewService.java
@@ -1,0 +1,33 @@
+package com.til.application.interview;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.til.domain.interview.dto.InterviewCreateDto;
+import com.til.domain.interview.dto.InterviewUuidDto;
+import com.til.domain.interview.model.Interview;
+import com.til.domain.interview.repository.InterviewRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class InterviewService {
+
+    private final InterviewRepository interviewRepository;
+
+    @Transactional
+    public InterviewUuidDto create(InterviewCreateDto interviewCreateDto) {
+        // todo: URL에 사용할 짧고 고유한 uuid 생성하여 대체
+        String uuid = "fresh uuid";
+
+        Interview interview = interviewCreateDto.toEntity(uuid);
+        interviewRepository.save(interview);
+
+        // todo: categoryList를 관계 테이블에 저장
+
+        return InterviewUuidDto.of(interview);
+    }
+
+}

--- a/til-domain/src/main/java/com/til/domain/interview/dto/InterviewCreateDto.java
+++ b/til-domain/src/main/java/com/til/domain/interview/dto/InterviewCreateDto.java
@@ -1,0 +1,26 @@
+package com.til.domain.interview.dto;
+
+import java.util.List;
+
+import com.til.domain.category.dto.CategoryDto;
+import com.til.domain.interview.model.Interview;
+import com.til.domain.interview.model.InterviewStatus;
+
+import lombok.Builder;
+
+@Builder
+public record InterviewCreateDto(
+                                 List<CategoryDto> categoryList,
+                                 InterviewStatus status,
+                                 String uuid,
+                                 Long userId
+) {
+
+    public Interview toEntity(String uuid) {
+        return Interview.builder()
+            .status(InterviewStatus.PROCESSING)
+            .uuid(uuid)
+            .userId(userId)
+            .build();
+    }
+}

--- a/til-domain/src/main/java/com/til/domain/interview/dto/InterviewUuidDto.java
+++ b/til-domain/src/main/java/com/til/domain/interview/dto/InterviewUuidDto.java
@@ -1,0 +1,17 @@
+package com.til.domain.interview.dto;
+
+import com.til.domain.interview.model.Interview;
+
+import lombok.Builder;
+
+@Builder
+public record InterviewUuidDto(
+                               String uuid
+) {
+
+    public static InterviewUuidDto of(Interview interview) {
+        return InterviewUuidDto.builder()
+            .uuid(interview.getUuid())
+            .build();
+    }
+}

--- a/til-domain/src/main/java/com/til/domain/interview/enums/InterviewSuccessCode.java
+++ b/til-domain/src/main/java/com/til/domain/interview/enums/InterviewSuccessCode.java
@@ -1,0 +1,16 @@
+package com.til.domain.interview.enums;
+
+import com.til.domain.common.enums.SuccessCode;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public enum InterviewSuccessCode implements SuccessCode {
+
+    SUCCESS_INTERVIEW_CREATION("모의면접 생성에 성공했습니다.");
+
+    private final String message;
+}

--- a/til-domain/src/main/java/com/til/domain/interview/model/Interview.java
+++ b/til-domain/src/main/java/com/til/domain/interview/model/Interview.java
@@ -1,0 +1,39 @@
+package com.til.domain.interview.model;
+
+import com.til.domain.common.model.BaseTimeEntity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+@Entity
+@Getter
+@SuperBuilder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "interview")
+public class Interview extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String uuid;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private InterviewStatus status;
+
+    @Column(nullable = false)
+    private Long userId;
+
+}

--- a/til-domain/src/main/java/com/til/domain/interview/model/InterviewStatus.java
+++ b/til-domain/src/main/java/com/til/domain/interview/model/InterviewStatus.java
@@ -1,0 +1,7 @@
+package com.til.domain.interview.model;
+
+public enum InterviewStatus {
+    PROCESSING,
+    DONE,
+    ABORTED
+}

--- a/til-domain/src/main/java/com/til/domain/interview/repository/InterviewRepository.java
+++ b/til-domain/src/main/java/com/til/domain/interview/repository/InterviewRepository.java
@@ -1,0 +1,9 @@
+package com.til.domain.interview.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.til.domain.interview.model.Interview;
+
+public interface InterviewRepository extends JpaRepository<Interview, Long> {
+
+}

--- a/til-domain/src/test/java/com/til/application/interview/InterviewServiceTest.java
+++ b/til-domain/src/test/java/com/til/application/interview/InterviewServiceTest.java
@@ -1,0 +1,45 @@
+package com.til.application.interview;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.til.domain.interview.dto.InterviewCreateDto;
+import com.til.domain.interview.dto.InterviewUuidDto;
+import com.til.domain.interview.model.InterviewStatus;
+import com.til.domain.interview.repository.InterviewRepository;
+
+@ExtendWith(MockitoExtension.class)
+public class InterviewServiceTest {
+
+    @InjectMocks
+    private InterviewService interviewService;
+
+    @Mock
+    private InterviewRepository interviewRepository;
+
+    @Test
+    void 모의면접을_정상적으로_생성하고_uuid를_받아온다() {
+        // given
+        String uuid = "fresh uuid";
+
+        // when
+        InterviewUuidDto interviewUuidDto = interviewService.create(createInterviewCreateDto(uuid));
+
+        // then
+        assertThat(interviewUuidDto.uuid()).isEqualTo(uuid);
+    }
+
+    private InterviewCreateDto createInterviewCreateDto(String uuid) {
+        return InterviewCreateDto.builder()
+            .status(InterviewStatus.PROCESSING)
+            .uuid(uuid)
+            .userId(1L)
+            .build();
+    }
+
+}


### PR DESCRIPTION
## 이슈 번호(링크)

[TIL-127](https://soma-til.atlassian.net/browse/TIL-127)

<br>

## 개요

- 모의 면접 생성 기능 구현

<br>

## 내용

![1](https://github.com/user-attachments/assets/ae522ea1-310c-438c-8db5-c706f1802367)
- 모의 면접(Interview) 테이블 엔티티 작성
<br>

![12](https://github.com/user-attachments/assets/f2bddcfa-6a32-42ae-b260-c1733153590c)
- 모의 면접 생성 POST API 작성
  - 관련 DTO 추가
  - 관련 Controller, Service, Repository 코드 추가
  - 관련 테스트 코드 추가
- 모의 면접 테이블 생성 ddl 추가

<br>

## 리뷰어한테 할 말

- 필요한 추가 작업
  - `uuid` 생성 유틸 클래스 작성
  - 연관 관계 테이블 엔티티 (카테고리 등) 작성


[TIL-127]: https://soma-til.atlassian.net/browse/TIL-127?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ