### PR TITLE
[TIL-167] Entity 클래스 set로직 제거

### DIFF
--- a/til-domain/src/main/java/com/til/application/problem/SolveProblemService.java
+++ b/til-domain/src/main/java/com/til/application/problem/SolveProblemService.java
@@ -1,5 +1,6 @@
 package com.til.application.problem;
 
+import java.util.Arrays;
 import java.util.Random;
 
 import org.springframework.stereotype.Service;
@@ -29,17 +30,17 @@ public class SolveProblemService {
     @Transactional
     public SolveProblemStatusDto solveProblem(SolveProblemDto solveProblemDto) {
         UserProblem userProblem = solveProblemDto.toEntity();
+        userProblemRepository.save(userProblem);
 
+        // TODO : 채점 요청 후 결과 가져오기
         ProblemStatus status = gradeStatus();
-        userProblem.setResultStatus(status);
-        UserProblem userProblemResult = userProblemRepository.save(userProblem);
-
-        return SolveProblemStatusDto.of(userProblemResult);
+        return SolveProblemStatusDto.of(status);
     }
 
     // To-do. 채점 로직 수정
     private ProblemStatus gradeStatus() {
-        ProblemStatus[] statuses = ProblemStatus.values();
+        ProblemStatus[] statuses = Arrays.stream(ProblemStatus.values())
+            .filter(status -> status != ProblemStatus.PENDING).toArray(ProblemStatus[]::new);
         Random random = new Random();
         int randomIndex = random.nextInt(statuses.length);
         return statuses[randomIndex];

--- a/til-domain/src/main/java/com/til/application/user/UserService.java
+++ b/til-domain/src/main/java/com/til/application/user/UserService.java
@@ -31,9 +31,7 @@ public class UserService {
     public void join(UserJoinDto userJoinDto) {
         checkJoinInfo(userJoinDto);
 
-        User user = userJoinDto.toEntity();
-        user.setPassword(encodePassword(userJoinDto.password()));
-
+        User user = userJoinDto.toEntityWithEncodedPassword(encodePassword(userJoinDto.password()));
         userRepository.save(user);
     }
 

--- a/til-domain/src/main/java/com/til/domain/problem/dto/SolveProblemStatusDto.java
+++ b/til-domain/src/main/java/com/til/domain/problem/dto/SolveProblemStatusDto.java
@@ -1,7 +1,6 @@
 package com.til.domain.problem.dto;
 
 import com.til.domain.problem.model.ProblemStatus;
-import com.til.domain.problem.model.UserProblem;
 
 import lombok.Builder;
 
@@ -10,9 +9,9 @@ public record SolveProblemStatusDto(
                                     ProblemStatus status
 ) {
 
-    public static SolveProblemStatusDto of(UserProblem userProblem) {
+    public static SolveProblemStatusDto of(ProblemStatus status) {
         return SolveProblemStatusDto.builder()
-            .status(userProblem.getStatus())
+            .status(status)
             .build();
     }
 }

--- a/til-domain/src/main/java/com/til/domain/problem/model/UserProblem.java
+++ b/til-domain/src/main/java/com/til/domain/problem/model/UserProblem.java
@@ -38,9 +38,4 @@ public class UserProblem extends BaseTimeEntity {
 
     @Column(nullable = false)
     private Long problemId;
-
-    public void setResultStatus(ProblemStatus status) {
-        this.status = status;
-    }
-
 }

--- a/til-domain/src/main/java/com/til/domain/user/dto/UserJoinDto.java
+++ b/til-domain/src/main/java/com/til/domain/user/dto/UserJoinDto.java
@@ -14,10 +14,10 @@ public record UserJoinDto(
                           String nickname
 ) {
 
-    public User toEntity() {
+    public User toEntityWithEncodedPassword(String encodedPassword) {
         return User.builder()
             .email(email)
-            .password(password)
+            .password(encodedPassword)
             .nickname(nickname)
             .platform(Platform.TIL)
             .role(Role.USER)

--- a/til-domain/src/main/java/com/til/domain/user/model/User.java
+++ b/til-domain/src/main/java/com/til/domain/user/model/User.java
@@ -13,7 +13,6 @@ import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 import lombok.experimental.SuperBuilder;
 
 @Entity
@@ -31,7 +30,6 @@ public class User extends BaseTimeEntity {
     private String email;
 
     @Column(nullable = false)
-    @Setter
     private String password;
 
     @Column(nullable = false)

--- a/til-domain/src/test/java/com/til/application/problem/SolveProblemServiceTest.java
+++ b/til-domain/src/test/java/com/til/application/problem/SolveProblemServiceTest.java
@@ -46,7 +46,7 @@ class SolveProblemServiceTest {
 
         // then
         assertThat(result).isNotNull();
-        assertThat(result.status()).isEqualTo(ProblemStatus.PASS);
+        assertThat(result.status()).isNotEqualTo(ProblemStatus.PENDING);
     }
 
     private SolveProblemDto createSolveProblemDto() {


### PR DESCRIPTION
## 이슈 번호(링크)

[TIL-167](https://soma-til.atlassian.net/browse/TIL-167)

<br>

## 개요
Entity 클래스 set로직 제거

<br>

## 내용
- User entity setPassword 메서드  
   UserJoinDto에서 암호화된 비밀번호로 설정하도록 이동
- UserProblem entity setResultStatus 메서드
   기본 status가 PENDING으로 설정되어 DB에 insert 된 뒤  
   채점 진행 후 status가 변동되는게 맞는 거 같아서 끊어서 임시 로직 구성

<br>

## 리뷰어한테 할 말
🍪

[TIL-167]: https://soma-til.atlassian.net/browse/TIL-167?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ