### PR TITLE
[TIL-162] Category 객체가 id값도 같이 반환/전송하도록 리팩토링

### DIFF
--- a/til-domain/src/main/java/com/til/domain/category/dto/CategoryDto.java
+++ b/til-domain/src/main/java/com/til/domain/category/dto/CategoryDto.java
@@ -6,11 +6,13 @@ import lombok.Builder;
 
 @Builder
 public record CategoryDto(
+                          Long id,
                           String tag
 ) {
 
     public static CategoryDto of(Category category) {
         return CategoryDto.builder()
+            .id(category.getId())
             .tag(category.getTag())
             .build();
     }


### PR DESCRIPTION
## 이슈 번호(링크)

[TIL-162](https://soma-til.atlassian.net/browse/TIL-162)

<br>

## 개요

- Category 객체가 id값도 같이 반환/전송하도록 리팩토링

<br>

## 내용

- Category 객체가 id값도 같이 반환/전송하도록 리팩토링

![1234](https://github.com/user-attachments/assets/326943fa-816b-4b6e-a4de-f80d2948c3b2)

- Interview 객체 생성 시 Category id만 보내도록 요청 방식을 변경했습니다!

<br>

## 리뷰어한테 할 말

🩸

[TIL-162]: https://soma-til.atlassian.net/browse/TIL-162?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ